### PR TITLE
co.jp supports IDN

### DIFF
--- a/metadata/co.jp.json
+++ b/metadata/co.jp.json
@@ -1,4 +1,0 @@
-{
-	"domain": "co.jp",
-	"codePoints": "--09az"
-}

--- a/zones.go
+++ b/zones.go
@@ -2786,7 +2786,7 @@ var _y = [4401]Zone{
 	{"akita.jp", &_z[744], nil, _c[0:6], nil, nil, nil, "", "", "", 0x0},
 	{"aomori.jp", &_z[744], nil, _c[0:6], nil, nil, nil, "", "", "", 0x0},
 	{"chiba.jp", &_z[744], nil, _c[0:6], nil, nil, nil, "", "", "", 0x0},
-	{"co.jp", &_z[744], nil, _c[0:6], nil, nil, nil, "", "", "", 0x0},
+	{"co.jp", &_z[744], nil, nil, nil, nil, nil, "", "", "", 0x0},
 	{"ed.jp", &_z[744], nil, _c[0:6], nil, nil, nil, "", "", "", 0x0},
 	{"ehime.jp", &_z[744], nil, _c[0:6], nil, nil, nil, "", "", "", 0x0},
 	{"fukui.jp", &_z[744], nil, _c[0:6], nil, nil, nil, "", "", "", 0x0},


### PR DESCRIPTION
Evidence: https://www.godaddy.com/dpp/find?domainToCheck=さむらい.co.jp&ci=83269&checkAvail=1&isc=ngtldawr15&utm_source=cj&utm_medium=affiliate&utm_campaign=xx-xx_corp_affiliate_base&utm_content=nb.io%2c%20LLC_2513766&utm_tgt=3198382