### PR TITLE
Unicode domain names in RDAP lookup

### DIFF
--- a/internal/build/iana_idn_tables.go
+++ b/internal/build/iana_idn_tables.go
@@ -112,4 +112,4 @@ func langFromURL(u string) (string, error) {
 	return normalizeLang(lang)
 }
 
-var errMalformedURL = errors.New("Malformed IDN table URL")
+var errMalformedURL = errors.New("malformed IDN table URL")

--- a/internal/build/rdap.go
+++ b/internal/build/rdap.go
@@ -42,8 +42,9 @@ func FetchRDAPFromIANA(zones map[string]*Zone) error {
 
 	for _, svc := range x.Services {
 		domains := svc[0]
-
 		for _, domain := range domains {
+			// Convert IDNA ASCII to Unicode form
+			domain = Normalize(domain)
 			z, ok := zones[domain]
 			if !ok {
 				Trace("@{y}domain %s not found in zones map\n", domain)

--- a/internal/build/zone.go
+++ b/internal/build/zone.go
@@ -15,8 +15,8 @@ import (
 type Zone struct {
 	Domain      string   `json:"domain,omitempty"`
 	InfoURL     string   `json:"infoURL,omitempty"`
-	WhoisURL    string   `json:"whoisURL,omitempty"`
 	WhoisServer string   `json:"whoisServer,omitempty"`
+	WhoisURL    string   `json:"whoisURL,omitempty"`
 	RDAPURLs    []string `json:"rdapURLs,omitempty"`
 	NameServers []string `json:"nameServers,omitempty"`
 	Wildcards   []string `json:"wildcards,omitempty"`


### PR DESCRIPTION
This PR fixes an issue in #836 where IDN domain names in the RDAP JSON file were IDNA (ASCII) encoded, and needed to be econverted to Unicode form before lookup.

It also swaps `WhoisServer` to be before `WhoisURL`, and fixes a staticcheck issue.