### PR TITLE
Improve logging on GitHub Actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,18 @@ install:
 	go install ./cmd/zonedb
 
 test:
-	go run cmd/zonedb/main.go
+	go run ./cmd/zonedb
 	go test ./...
 
 zones.go: zones.txt metadata/*.json internal/* internal/*/*
 	go generate
 
 update:
-	go run cmd/zonedb/main.go -update -w -c 100 $(ZONEDB_ARGS)
+	go run ./cmd/zonedb -update -w -c 10 $(ZONEDB_ARGS)
 	$(MAKE) zones.go
 
 normalize:
-	go run cmd/zonedb/main.go -w
+	go run ./cmd/zonedb -w
 	$(MAKE) zones.go
 
 git_revision=$(shell git describe --no-tags --always --dirty --abbrev=0)

--- a/internal/build/dns.go
+++ b/internal/build/dns.go
@@ -223,7 +223,8 @@ func verifyNS(host string) error {
 	if err != nil {
 		return err
 	}
-	Trace("@{.}.")
+	// Do long colored lines break GitHub Actions logging?
+	// Trace("@{.}.")
 	err = CanDial("udp", host+":53")
 	return err
 }

--- a/internal/build/dns.go
+++ b/internal/build/dns.go
@@ -39,9 +39,7 @@ func FetchRootZone(zones map[string]*Zone, addNew bool) error {
 	}
 
 	zp := dns.NewZoneParser(res.Body, "", "")
-
-	limiter := make(chan struct{}, Concurrency)
-	var wg sync.WaitGroup
+	rrs := make(map[string]dns.RR)
 
 	for rr, ok := zp.Next(); ok; rr, ok = zp.Next() {
 		h := rr.Header()
@@ -49,10 +47,21 @@ func FetchRootZone(zones map[string]*Zone, addNew bool) error {
 			continue
 		}
 		d := Normalize(h.Name)
-		if d == "" {
-			continue
+		if d != "" {
+			rrs[d] = rr
 		}
+	}
 
+	if err := zp.Err(); err != nil {
+		return err
+	}
+
+	color.Fprintf(os.Stderr, "@{.}Verifying %d RRs in root zone...\n", len(rrs))
+
+	limiter := make(chan struct{}, Concurrency)
+	var wg sync.WaitGroup
+
+	for d, rr := range rrs {
 		// Identify the zone
 		z := zones[d]
 		if z == nil {
@@ -81,10 +90,6 @@ func FetchRootZone(zones map[string]*Zone, addNew bool) error {
 	}
 
 	wg.Wait()
-
-	if err := zp.Err(); err != nil {
-		return err
-	}
 
 	// Detect retired or withdrawn TLDs
 	for _, z := range zones {


### PR DESCRIPTION
- Makefile: set concurrency = 10 by default (was 100); use ./cmd path
- internal/build: disable logging . in verifyNS
- internal/build: parse root zone in one pass, verify in second pass
