### PR TITLE
Specify Ubuntu version for GH Actions runner

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   test-go:
     name: Test, Vet, Vulncheck Go code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
       matrix:
@@ -53,7 +53,7 @@ jobs:
   # Test with TinyGo
   test-tinygo-wasm:
     name: Test with WASM and TinyGo
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
       matrix:
@@ -109,7 +109,7 @@ jobs:
   # Tag release
   tag-release:
     name: Tag release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 1
     needs: [test-go, test-tinygo-wasm]
     steps:


### PR DESCRIPTION
I'm seeing this warning in the Actions output:

> `ubuntu-latest` pipelines will use `ubuntu-24.04` soon. For more details, see https://github.com/actions/runner-images/issues/10636

I'd rather that we manually cut over to 24 at some point, than be surprised if it doesn't immediately work for some reason.