### PR TITLE
Add a test to ensure that ccTLDs aren't tagged as Brands

### DIFF
--- a/zones_test.go
+++ b/zones_test.go
@@ -303,3 +303,11 @@ func TestSpecialDomainPolicies(t *testing.T) {
 		})
 	}
 }
+
+func TestNoCcTLDsHaveBrandTag(t *testing.T) {
+	for _, z := range Zones {
+		if z.Tags.And(TagCountry) && z.Tags.And(TagBrand) {
+			t.Errorf("ccTLD %q should not have brand tag", z.Domain)
+		}
+	}
+}


### PR DESCRIPTION
Confirmed by tagging `uk` with `brand` and I see this output:

```
=== RUN   TestNoCcTLDsHaveBrandTag
    zones_test.go:310: ccTLD "uk" should not have brand tag
--- FAIL: TestNoCcTLDsHaveBrandTag (0.00s)
```