### PR TITLE
ci: verify whois when generating json files

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -6,7 +6,7 @@ on:
       zonedbArgs:
         description: "zonedb arguments"
         required: false
-        default: ""
+        default: "-verify-whois"
   schedule:
     - cron: "07 8 * * *" # 08:07 UTC, or 12:07 AM PT
 


### PR DESCRIPTION
We (domainr) see a lot of errors connecting to whois servers.

The whois information is sourced from ZoneDB, and it turns out we already have a way to validate if those whois servers are actually running/accessible (`--verify-whois`).

The CI runs daily, so even if there's a temporarily blip with a whois server, if it's back up and running by the next day it'll be included in the next run of the ZoneDB data.

That said, whois servers are generally being decommissioned so we'll end up seeing more and more errors from whois connections in domainr if we don't filter the inactive servers.