### PR TITLE
Go version updates

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -132,8 +132,8 @@ jobs:
 
       - name: Add Go wasm exec to $PATH (for Go < 1.24 and Go >= 1.24)
         run: |
-          echo "$(go env GOROOT)/misc/wasm" >> $GITHUB_PATH
-          echo "$(go env GOROOT)/lib/wasm" >> $GITHUB_PATH
+          echo "$(go env GOROOT)/misc/wasm" >> "$GITHUB_PATH"
+          echo "$(go env GOROOT)/lib/wasm" >> "$GITHUB_PATH"
 
       - name: Check for wasmtime bridge
         run: which go_wasip1_wasm_exec

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -102,17 +102,17 @@ jobs:
       # Go version from go.mod. See usage in the actions/setup-go step.
       matrix:
         go-version:
-          - big: "1.24"
-            tiny: "0.36.0"
-          - big: "1.24"
-            tiny: "0.37.0"
+          - big: "1.25"
+            tiny: "0.39.0"
+          - big: "1.25"
+            tiny: "0.40.1"
         # FIXME: TinyGo needs to be manually bumped; it doesn't immediately
         # release support for new major Go versions something should ping when a
         # new version is available.
         include:
           - go-version:
               file: "go.mod"
-              tiny: "0.37.0"
+              tiny: "0.40.1"
 
     env:
       GODEBUG: toolchaintrace=1

--- a/.github/workflows/update-go-versions.yaml
+++ b/.github/workflows/update-go-versions.yaml
@@ -24,16 +24,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          OUTPUT=$(scripts/go-versions-check.sh 2>&1) && NEEDS_UPDATE=false || NEEDS_UPDATE=true
+          OUTPUT=$(scripts/go-versions-check.sh 2>&1) || true
           echo "$OUTPUT"
-          echo "needs_update=$NEEDS_UPDATE" >> "$GITHUB_OUTPUT"
-          eval "$(echo "$OUTPUT" | grep '^[A-Z_][A-Z_]*=')"
-          {
-            echo "go_prev=$GO_PREV"
-            echo "tinygo_go=$TINYGO_GO"
-            echo "tinygo_prev=$TINYGO_PREV"
-            echo "tinygo_latest=$TINYGO_LATEST"
-          } >> "$GITHUB_OUTPUT"
+          # Forward machine-readable values (e.g. GO_PREV=1.25) to GITHUB_OUTPUT as lowercase keys
+          echo "$OUTPUT" | grep '^[A-Z][A-Z_]*=' | tr '[:upper:]' '[:lower:]' >> "$GITHUB_OUTPUT"
 
       - name: Set up Go
         if: steps.check.outputs.needs_update == 'true'
@@ -57,23 +51,25 @@ jobs:
           TINYGO_LATEST: ${{ steps.check.outputs.tinygo_latest }}
         run: |
           BRANCH="update-go-versions"
+          TITLE="Update Go to ${GO_PREV}.0, TinyGo to ${TINYGO_LATEST}"
           git checkout -b "$BRANCH"
           git add go.mod go.sum .github/workflows/go.yaml
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "Update Go to ${GO_PREV}.0, TinyGo to ${TINYGO_LATEST}"
-          git push -f origin "$BRANCH"
+          git commit -m "$TITLE"
+          git push --force-with-lease origin "$BRANCH"
           EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING_PR" ]; then
-            echo "PR #$EXISTING_PR already exists, updated branch."
+            gh pr edit "$EXISTING_PR" --title "$TITLE"
+            echo "Updated PR #$EXISTING_PR."
           else
             gh pr create \
-              --title "Update Go to ${GO_PREV}.0, TinyGo to ${TINYGO_LATEST}" \
+              --title "$TITLE" \
               --body "Automated version update per [Go release policy](https://go.dev/doc/devel/release#policy).
 
           - go.mod minimum: \`go ${GO_PREV}.0\`
-          - go.yaml Go version for TinyGo tests: \`${TINYGO_GO}\`
-          - go.yaml TinyGo versions: \`${TINYGO_PREV}\`, \`${TINYGO_LATEST}\`
+          - CI Go version for TinyGo tests: \`${TINYGO_GO}\`
+          - CI TinyGo versions: \`${TINYGO_PREV}\`, \`${TINYGO_LATEST}\`
 
           > [!NOTE]
           > This PR was created by the \`update-go-versions\` workflow.

--- a/.github/workflows/update-go-versions.yaml
+++ b/.github/workflows/update-go-versions.yaml
@@ -1,0 +1,81 @@
+name: Update Go & TinyGo Versions
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Weekly Monday 9am UTC
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-versions:
+    name: Update Go & TinyGo Versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Check versions
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          OUTPUT=$(scripts/go-versions-check.sh 2>&1) && NEEDS_UPDATE=false || NEEDS_UPDATE=true
+          echo "$OUTPUT"
+          echo "needs_update=$NEEDS_UPDATE" >> "$GITHUB_OUTPUT"
+          eval "$(echo "$OUTPUT" | grep '^[A-Z_]*=')"
+          {
+            echo "go_prev=$GO_PREV"
+            echo "tinygo_go=$TINYGO_GO"
+            echo "tinygo_prev=$TINYGO_PREV"
+            echo "tinygo_latest=$TINYGO_LATEST"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        if: steps.check.outputs.needs_update == 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Update files
+        if: steps.check.outputs.needs_update == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/go-versions-update.sh
+
+      - name: Create pull request
+        if: steps.check.outputs.needs_update == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GO_PREV: ${{ steps.check.outputs.go_prev }}
+          TINYGO_GO: ${{ steps.check.outputs.tinygo_go }}
+          TINYGO_PREV: ${{ steps.check.outputs.tinygo_prev }}
+          TINYGO_LATEST: ${{ steps.check.outputs.tinygo_latest }}
+        run: |
+          BRANCH="update-go-versions"
+          git checkout -b "$BRANCH"
+          git add go.mod go.sum .github/workflows/go.yaml
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Update Go to ${GO_PREV}.0, TinyGo to ${TINYGO_LATEST}"
+          git push -f origin "$BRANCH"
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists, updated branch."
+          else
+            gh pr create \
+              --title "Update Go to ${GO_PREV}.0, TinyGo to ${TINYGO_LATEST}" \
+              --body "Automated version update per [Go release policy](https://go.dev/doc/devel/release#policy).
+
+          - go.mod minimum: \`go ${GO_PREV}.0\`
+          - go.yaml Go version for TinyGo tests: \`${TINYGO_GO}\`
+          - go.yaml TinyGo versions: \`${TINYGO_PREV}\`, \`${TINYGO_LATEST}\`
+
+          > [!NOTE]
+          > This PR was created by the \`update-go-versions\` workflow.
+          > CI won't run automatically — close and reopen to trigger tests."
+          fi

--- a/.github/workflows/update-go-versions.yaml
+++ b/.github/workflows/update-go-versions.yaml
@@ -27,7 +27,7 @@ jobs:
           OUTPUT=$(scripts/go-versions-check.sh 2>&1) && NEEDS_UPDATE=false || NEEDS_UPDATE=true
           echo "$OUTPUT"
           echo "needs_update=$NEEDS_UPDATE" >> "$GITHUB_OUTPUT"
-          eval "$(echo "$OUTPUT" | grep '^[A-Z_]*=')"
+          eval "$(echo "$OUTPUT" | grep '^[A-Z_][A-Z_]*=')"
           {
             echo "go_prev=$GO_PREV"
             echo "tinygo_go=$TINYGO_GO"

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -62,7 +62,7 @@ jobs:
           [[ -z $(git status -s) ]] || ( git add -v --all .
             git config --global user.email robot@zonedb.org
             git config --global user.name zonedbot
-            git commit -m "Automatic update for `date -u`"
+            git commit -m "Automatic update for $(date -u)"
             git push origin -u HEAD
           )
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+version: "2"
+
+linters:
+  default: standard
+  settings:
+    errcheck:
+      exclude-functions:
+        # Cosmetic terminal color output to stderr — errors are meaningless.
+        - github.com/wsxiaoys/terminal/color.Fprintf
+        # Deferred and post-read Close() calls — error on close after
+        # successful read is harmless for HTTP bodies, files, and connections.
+        - (io.Closer).Close

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,3 +10,5 @@ linters:
         # Deferred and post-read Close() calls — error on close after
         # successful read is harmless for HTTP bodies, files, and connections.
         - (io.Closer).Close
+        - (*os.File).Close
+        - (net.Conn).Close

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+---
+extends: default
+rules:
+  document-start: disable
+  truthy: disable
+  line-length: disable
+  comments:
+    min-spaces-from-content: 1

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,14 @@ tag-version: .git/refs/heads/main
 	git tag $(tag_version) $(git_revision)
 	git push --tags
 
+.PHONY: go-versions-check
+go-versions-check:
+	@scripts/go-versions-check.sh || true
+
+.PHONY: go-versions-update
+go-versions-update:
+	scripts/go-versions-update.sh
+
 .PHONY: test-makefile-integrity
 test-makefile-integrity:
 	@echo ">>> Testing 'make install'..."

--- a/cmd/lint
+++ b/cmd/lint
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# cmd/lint — run all linters for the zonedb project.
+# Missing optional tools are skipped, not failed.
+#
+set -euo pipefail
+
+cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+
+passed=0
+failed=0
+skipped=0
+failures=()
+
+# Run a named lint check. Fails on non-zero exit code.
+check() {
+  local name="$1"; shift
+  local output rc=0
+  output=$("$@" 2>&1) || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    printf "  ✅  %s\n" "$name"
+    passed=$((passed + 1))
+  else
+    printf "  ❌  %s\n" "$name"
+    printf '%s\n' "$output" | head -20 | sed 's/^/       /'
+    failed=$((failed + 1))
+    failures+=("$name")
+  fi
+}
+
+# Like check, but skips when the tool is not on PATH.
+check_optional() {
+  local name="$1" tool="$2"
+  if ! command -v "$tool" &>/dev/null; then
+    printf "  SKIP  %s (%s not installed)\n" "$name" "$tool"
+    skipped=$((skipped + 1))
+    return 0
+  fi
+  check "$name" "${@:2}"
+}
+
+# --- Go ----------------------------------------------------------------
+echo "Go"
+check "gofmt" bash -c '
+  out=$(gofmt -l .)
+  if [ -n "$out" ]; then
+    echo "$out"
+    exit 1
+  fi'
+check "go vet" go vet ./...
+check_optional "golangci-lint" golangci-lint run ./...
+
+# --- Shell --------------------------------------------------------------
+echo ""
+echo "Shell"
+shell_files=$(find . -name '*.sh' -not -path './.git/*' -type f 2>/dev/null || true)
+if [ -n "$shell_files" ]; then
+  # shellcheck disable=SC2086
+  check_optional "shellcheck" shellcheck $shell_files
+else
+  printf "  SKIP  shellcheck (no .sh files)\n"
+  skipped=$((skipped + 1))
+fi
+
+# --- YAML ---------------------------------------------------------------
+echo ""
+echo "YAML"
+check_optional "yamllint" yamllint .github/
+check_optional "actionlint" actionlint
+
+# --- TOML ---------------------------------------------------------------
+echo ""
+echo "TOML"
+check "toml syntax" python3 -c "
+import tomllib, sys, pathlib
+errors = []
+for f in sorted(pathlib.Path('.').rglob('*.toml')):
+    try:
+        tomllib.loads(f.read_text())
+    except Exception as e:
+        errors.append(f'{f}: {e}')
+if errors:
+    print('\n'.join(errors), file=sys.stderr)
+    sys.exit(1)
+"
+
+# --- Dockerfile ----------------------------------------------------------
+echo ""
+echo "Dockerfile"
+dockerfile_files=$(find . -name 'Dockerfile*' -not -path './.git/*' -type f 2>/dev/null || true)
+if [ -n "$dockerfile_files" ]; then
+  # shellcheck disable=SC2086
+  check_optional "hadolint" hadolint $dockerfile_files
+else
+  printf "  SKIP  hadolint (no Dockerfiles)\n"
+  skipped=$((skipped + 1))
+fi
+
+# --- Summary -------------------------------------------------------------
+echo ""
+if [ "$failed" -eq 0 ]; then
+  printf "✅ All %d checks passed" "$passed"
+  [ "$skipped" -gt 0 ] && printf " (%d skipped)" "$skipped"
+  printf ".\n"
+else
+  printf "❌ %d passed, %d failed" "$passed" "$failed"
+  [ "$skipped" -gt 0 ] && printf ", %d skipped" "$skipped"
+  printf ": %s\n" "${failures[*]}"
+  exit 1
+fi

--- a/cmd/zonedb/main.go
+++ b/cmd/zonedb/main.go
@@ -88,7 +88,11 @@ func main() {
 		if err := cache.Load(); err != nil {
 			color.Fprintf(os.Stderr, "@{y}Warning: failed to load ETag cache, starting fresh: %s\n", err)
 		}
-		defer cache.Save()
+		defer func() {
+			if err := cache.Save(); err != nil {
+				color.Fprintf(os.Stderr, "@{y}Warning: failed to save ETag cache: %s\n", err)
+			}
+		}()
 	}
 
 	startTime := time.Now()

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/zonedb/zonedb
 
-// Minimum supported Go version
-// (current version -2, except when security fixes are only backported to the current version -1)
-// Note: this should use the latest dot release in CI, once GitHub has added it to "actions/go-versions"
-//
-// EDIT[2025.12.09]: golang.org/x/net requires go1.24.0 - so we have to avoid go1.23.x
+// Minimum supported Go version: the older of the two most recent major
+// releases, per the Go release policy: https://go.dev/doc/devel/release#policy
+// Checked automatically by .github/workflows/update-go-versions.yaml
 go 1.24.10
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/zonedb/zonedb
 // Minimum supported Go version: the older of the two most recent major
 // releases, per the Go release policy: https://go.dev/doc/devel/release#policy
 // Checked automatically by .github/workflows/update-go-versions.yaml
-go 1.24.10
+go 1.25.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/internal/build/centralnic_idn_tables.go
+++ b/internal/build/centralnic_idn_tables.go
@@ -153,9 +153,8 @@ func FetchIDNTablesFromCentralNic(zones map[string]*Zone, cache *ETagCache) erro
 
 	// Normalize mnemonics and collect detail page fetches
 	type fetchJob struct {
-		lang     string
-		entry    centralNicEntry
-		detailID string // URL path suffix for the detail page
+		lang  string
+		entry centralNicEntry
 	}
 	var jobs []fetchJob
 	for _, entry := range entries {

--- a/internal/build/centralnic_idn_tables_test.go
+++ b/internal/build/centralnic_idn_tables_test.go
@@ -169,7 +169,7 @@ func centralNicTestHandler() http.Handler {
 	// For any other detail page, serve an empty page (no zones)
 	mux.HandleFunc("/services/idn-table/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte(`<!doctype html><html><body></body></html>`))
+		_, _ = w.Write([]byte(`<!doctype html><html><body></body></html>`))
 	})
 
 	return mux

--- a/internal/build/dns.go
+++ b/internal/build/dns.go
@@ -384,7 +384,7 @@ func randLabel(n int) string {
 
 func exchange(ctx context.Context, host, qname string, qtype uint16) (*dns.Msg, error) {
 	qmsg := &dns.Msg{}
-	qmsg.MsgHdr.RecursionDesired = true
+	qmsg.RecursionDesired = true
 	qmsg.SetQuestion(dns.Fqdn(qname), qtype)
 	client := &dns.Client{}
 	// if deadline, ok := ctx.Deadline(); ok {

--- a/internal/build/files_test.go
+++ b/internal/build/files_test.go
@@ -106,7 +106,6 @@ func TestMetadataLanguageTagsValid(t *testing.T) {
 	t.Logf("validated %d language tags across %d zones", checked, len(zones))
 }
 
-
 // TestMetadataCCTLDsHaveCountryName validates that every country-code TLD has
 // a countryName populated.
 func TestMetadataCCTLDsHaveCountryName(t *testing.T) {

--- a/internal/build/iana_root_db.go
+++ b/internal/build/iana_root_db.go
@@ -38,7 +38,7 @@ var idnToAsciiOverrides = map[string]string{
 	"xn--90ae": "bg", // .бг
 
 	// Sri Lanka: "LK Domain Registry" vs "Council for Information Technology LK Domain Registrar"
-	"xn--fzc2c9e2c":   "lk", // .ලංකා (Sinhala)
+	"xn--fzc2c9e2c":    "lk", // .ලංකා (Sinhala)
 	"xn--xkc2al3hye2a": "lk", // .இலங்கை (Tamil)
 
 	// Ukraine: "Ukrainian Network Information Centre (UANIC), Inc." vs "Hostmaster Ltd."
@@ -48,7 +48,7 @@ var idnToAsciiOverrides = map[string]string{
 	"xn--l1acc": "mn", // .мон
 
 	// TRA disambiguations: Telecommunications Regulatory Authority manages both .bh and .om
-	"xn--mgb9awbf":   "om", // .عمان (Oman)
+	"xn--mgb9awbf":     "om", // .عمان (Oman)
 	"xn--mgbcpq6gpa1a": "bh", // .البحرين (Bahrain)
 
 	// Iran: "Institute for Research in Fundamental Sciences (IPM)" vs without "(IPM)"
@@ -148,8 +148,8 @@ func applyRootDBIndex(zones map[string]*Zone, doc *goquery.Document) error {
 
 	// Pre-compute normalized (Unicode) domain for each entry, and build
 	// lookups needed for IDN→ASCII mapping.
-	normalized := make([]string, len(entries))         // parallel to entries
-	orgToAscii := make(map[string][]string)            // org → []ASCII domain
+	normalized := make([]string, len(entries)) // parallel to entries
+	orgToAscii := make(map[string][]string)    // org → []ASCII domain
 	for i, e := range entries {
 		normalized[i] = Normalize(e.Punycode)
 		if e.Type == "country-code" && !strings.HasPrefix(e.Punycode, "xn--") {

--- a/internal/build/iana_root_db_test.go
+++ b/internal/build/iana_root_db_test.go
@@ -271,12 +271,12 @@ func TestApplyRootDBIndex(t *testing.T) {
 	// Every TLD should get a type-based tag matching its IANA classification.
 	t.Run("TypeTags", func(t *testing.T) {
 		typeToTag := map[string]string{
-			"country-code":     TagCountry,
-			"generic":          TagGeneric,
+			"country-code":       TagCountry,
+			"generic":            TagGeneric,
 			"generic-restricted": TagGeneric,
-			"sponsored":        TagSponsored,
-			"infrastructure":   TagInfrastructure,
-			"test":             TagTest,
+			"sponsored":          TagSponsored,
+			"infrastructure":     TagInfrastructure,
+			"test":               TagTest,
 		}
 		for _, e := range entries {
 			wantTag, ok := typeToTag[e.Type]

--- a/internal/build/iana_special_test.go
+++ b/internal/build/iana_special_test.go
@@ -8,9 +8,9 @@ import (
 
 func TestStripDeprecatedSuffix(t *testing.T) {
 	tests := []struct {
-		input        string
-		wantDomain   string
-		wantRetired  bool
+		input       string
+		wantDomain  string
+		wantRetired bool
 	}{
 		// Deprecated markers should be stripped
 		{"eap-noob.arpa. (DEPRECATED)", "eap-noob.arpa", true},

--- a/internal/build/idn_overrides_test.go
+++ b/internal/build/idn_overrides_test.go
@@ -28,16 +28,6 @@ func TestApplyIDNOverrides(t *testing.T) {
 	defer func() { IDNOverrides = origOverrides }()
 
 	zones := map[string]*Zone{
-		"source": {Domain: "aaa"},  // .aaa exists in the fixture
-		"target": {Domain: "target"},
-	}
-
-	// Populate source from fixture.
-	// Note: source has Domain "aaa" so FetchIDNTablesFromIANA matches
-	// IANA entries for .aaa. But the zones map key is "source" so the
-	// fetch won't find it. We need to use the real domain.
-	// Let's restructure: use real domain names.
-	zones = map[string]*Zone{
 		"aaa": {Domain: "aaa"},
 		"cc":  {Domain: "cc"},
 	}

--- a/internal/build/info_urls.go
+++ b/internal/build/info_urls.go
@@ -2,7 +2,6 @@ package build
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -73,7 +72,7 @@ func UpdateInfoURLs(zones map[string]*Zone) {
 				}
 				continue
 			}
-			CloseN(res.Body, 10_000_000)
+			_, _ = CloseN(res.Body, 10_000_000)
 			// Don’t use redirected URL, use the URL we crafted
 			// infoURL = NormalizeURL(res.Request.URL.String())
 			infoURL = u
@@ -97,21 +96,10 @@ func UpdateInfoURLs(zones map[string]*Zone) {
 // It returns the number of bytes drained and the first error encountered.
 // Regardless of any errors, rc.Close() is guaranteed to be called.
 func CloseN(rc io.ReadCloser, n int64) (int64, error) {
-	n, cerr := io.Copy(ioutil.Discard, io.LimitReader(rc, n))
+	n, cerr := io.Copy(io.Discard, io.LimitReader(rc, n))
 	err := rc.Close()
 	if cerr != nil {
 		err = cerr
 	}
 	return n, err
-}
-
-// trimURL trims query strings and /index.htm(l)? from a URL.
-func trimURL(u string) string {
-	u, _, _ = strings.Cut(u, "?")
-	if strings.HasSuffix(u, "/index.html") {
-		u = strings.TrimSuffix(u, "/index.html")
-	} else {
-		u = strings.TrimSuffix(u, "/index.htm")
-	}
-	return u
 }

--- a/scripts/go-versions-check.sh
+++ b/scripts/go-versions-check.sh
@@ -43,18 +43,18 @@ CUR_TINY_LATEST=$(sed -n 's/.*tiny: "\([0-9.]*\)".*/\1/p' .github/workflows/go.y
 CUR_GOMOD=$(sed -n 's/^go \([0-9.]*\).*/\1/p' go.mod)
 
 echo "=== Go & TinyGo Version Check ==="
-echo "Go stable releases:  $GO_PREV, $GO_CURRENT"
-echo "TinyGo releases:     $TINYGO_PREV, $TINYGO_LATEST (supports up to Go $TINYGO_MAX_GO)"
+echo "Go stable releases:       $GO_PREV, $GO_CURRENT"
+echo "TinyGo releases:          $TINYGO_PREV, $TINYGO_LATEST (supports up to Go $TINYGO_MAX_GO)"
 echo ""
-echo "go.mod minimum:      $CUR_GOMOD -> ${GO_PREV}.0"
-echo "go.yaml Go (TinyGo): $CUR_BIG -> $TINYGO_GO"
-echo "go.yaml TinyGo:      $CUR_TINY_PREV, $CUR_TINY_LATEST -> $TINYGO_PREV, $TINYGO_LATEST"
+echo "go.mod minimum:           $CUR_GOMOD -> ${GO_PREV}.0"
+echo "go.yaml CI Go (TinyGo):   $CUR_BIG -> $TINYGO_GO"
+echo "go.yaml CI TinyGo:        $CUR_TINY_PREV, $CUR_TINY_LATEST -> $TINYGO_PREV, $TINYGO_LATEST"
 
 # Check if updates are needed
 NEEDS_UPDATE=false
-[ "$CUR_BIG" != "$TINYGO_GO" ] && NEEDS_UPDATE=true || true
-[ "$CUR_TINY_LATEST" != "$TINYGO_LATEST" ] && NEEDS_UPDATE=true || true
-[ "$CUR_GOMOD" != "${GO_PREV}.0" ] && NEEDS_UPDATE=true || true
+if [ "$CUR_BIG" != "$TINYGO_GO" ]; then NEEDS_UPDATE=true; fi
+if [ "$CUR_TINY_LATEST" != "$TINYGO_LATEST" ]; then NEEDS_UPDATE=true; fi
+if [ "$CUR_GOMOD" != "${GO_PREV}.0" ]; then NEEDS_UPDATE=true; fi
 echo ""
 echo "Needs update: $NEEDS_UPDATE"
 
@@ -69,4 +69,4 @@ echo "CUR_TINY_PREV=$CUR_TINY_PREV"
 echo "CUR_TINY_LATEST=$CUR_TINY_LATEST"
 echo "NEEDS_UPDATE=$NEEDS_UPDATE"
 
-[ "$NEEDS_UPDATE" = "true" ] && exit 1 || exit 0
+if [ "$NEEDS_UPDATE" = "true" ]; then exit 1; else exit 0; fi

--- a/scripts/go-versions-check.sh
+++ b/scripts/go-versions-check.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Detect current and required Go/TinyGo versions.
+# Prints a summary and exits 0 if up to date, 1 if updates are needed.
+#
+# Requires: curl, jq, gh (authenticated), sed
+#
+set -euo pipefail
+
+cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+
+# Two most recent stable Go major.minor versions
+# e.g. "1.25\n1.26"
+GO_VERSIONS=$(curl -sS 'https://go.dev/dl/?mode=json' | \
+  jq -r '[.[] | select(.stable) | .version | ltrimstr("go") | split(".")[0:2] | join(".")] | unique | sort | .[-2:][]')
+GO_PREV=$(echo "$GO_VERSIONS" | head -1)   # e.g. "1.25"
+GO_CURRENT=$(echo "$GO_VERSIONS" | tail -1) # e.g. "1.26"
+
+# Two most recent TinyGo releases with distinct minor versions
+# e.g. "0.39.0\n0.40.1" (latest patch of each minor)
+TINYGO_VERSIONS=$(gh api repos/tinygo-org/tinygo/releases --jq \
+  '[.[] | select(.prerelease | not) | .tag_name | ltrimstr("v")] | group_by(split(".")[0:2] | join(".")) | map(sort | last) | sort | .[-2:][]')
+TINYGO_PREV=$(echo "$TINYGO_VERSIONS" | head -1)   # e.g. "0.39.0"
+TINYGO_LATEST=$(echo "$TINYGO_VERSIONS" | tail -1) # e.g. "0.40.1"
+
+# Highest Go minor version TinyGo supports, e.g. "1.25"
+# Parsed from TinyGo source: `const minorMax = 25` -> "1.25"
+TINYGO_MAX_GO="1.$(curl -sS 'https://raw.githubusercontent.com/tinygo-org/tinygo/release/builder/config.go' | \
+  sed -n 's/.*minorMax[[:space:]]*=[[:space:]]*\([0-9]*\).*/\1/p')"
+
+# TinyGo tests should use the oldest supported Go that TinyGo can handle
+if [ "$(printf '%s\n%s' "$GO_PREV" "$TINYGO_MAX_GO" | sort -V | head -1)" = "$GO_PREV" ]; then
+  TINYGO_GO="$GO_PREV"
+else
+  echo "WARNING: TinyGo $TINYGO_LATEST only supports up to Go $TINYGO_MAX_GO (older than previous stable $GO_PREV)"
+  TINYGO_GO="$TINYGO_MAX_GO"
+fi
+
+# What's currently in the repo
+CUR_BIG=$(sed -n 's/.*big: "\([0-9.]*\)".*/\1/p' .github/workflows/go.yaml | head -1)
+CUR_TINY_PREV=$(sed -n 's/.*tiny: "\([0-9.]*\)".*/\1/p' .github/workflows/go.yaml | sort -V | uniq | head -1)
+CUR_TINY_LATEST=$(sed -n 's/.*tiny: "\([0-9.]*\)".*/\1/p' .github/workflows/go.yaml | sort -V | uniq | tail -1)
+CUR_GOMOD=$(sed -n 's/^go \([0-9.]*\).*/\1/p' go.mod)
+
+echo "=== Go & TinyGo Version Check ==="
+echo "Go stable releases:  $GO_PREV, $GO_CURRENT"
+echo "TinyGo releases:     $TINYGO_PREV, $TINYGO_LATEST (supports up to Go $TINYGO_MAX_GO)"
+echo ""
+echo "go.mod minimum:      $CUR_GOMOD -> ${GO_PREV}.0"
+echo "go.yaml Go (TinyGo): $CUR_BIG -> $TINYGO_GO"
+echo "go.yaml TinyGo:      $CUR_TINY_PREV, $CUR_TINY_LATEST -> $TINYGO_PREV, $TINYGO_LATEST"
+
+# Check if updates are needed
+NEEDS_UPDATE=false
+[ "$CUR_BIG" != "$TINYGO_GO" ] && NEEDS_UPDATE=true || true
+[ "$CUR_TINY_LATEST" != "$TINYGO_LATEST" ] && NEEDS_UPDATE=true || true
+[ "$CUR_GOMOD" != "${GO_PREV}.0" ] && NEEDS_UPDATE=true || true
+echo ""
+echo "Needs update: $NEEDS_UPDATE"
+
+# Machine-readable values (used by go-versions-update.sh)
+echo ""
+echo "GO_PREV=$GO_PREV"
+echo "TINYGO_GO=$TINYGO_GO"
+echo "TINYGO_PREV=$TINYGO_PREV"
+echo "TINYGO_LATEST=$TINYGO_LATEST"
+echo "CUR_BIG=$CUR_BIG"
+echo "CUR_TINY_PREV=$CUR_TINY_PREV"
+echo "CUR_TINY_LATEST=$CUR_TINY_LATEST"
+echo "NEEDS_UPDATE=$NEEDS_UPDATE"
+
+[ "$NEEDS_UPDATE" = "true" ] && exit 1 || exit 0

--- a/scripts/go-versions-update.sh
+++ b/scripts/go-versions-update.sh
@@ -12,8 +12,16 @@ cd "$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 
 # Run check script and extract KEY=VALUE pairs
 CHECK_OUTPUT=$("$SCRIPT_DIR/go-versions-check.sh" 2>&1) || true
-echo "$CHECK_OUTPUT" | grep -v '^[A-Z_][A-Z_]*='
-eval "$(echo "$CHECK_OUTPUT" | grep '^[A-Z_][A-Z_]*=')"
+echo "$CHECK_OUTPUT" | grep -v '^[A-Z][A-Z_]*='
+
+# Validate and eval only version-like values (security: reject anything unexpected)
+VERSION_LINES=$(echo "$CHECK_OUTPUT" | grep '^[A-Z][A-Z_]*=')
+if echo "$VERSION_LINES" | grep -qv '^[A-Z][A-Z_]*=[a-z0-9.]*$'; then
+  echo "ERROR: unexpected value in check output:"
+  echo "$VERSION_LINES" | grep -v '^[A-Z][A-Z_]*=[a-z0-9.]*$'
+  exit 1
+fi
+eval "$VERSION_LINES"
 
 if [ "$NEEDS_UPDATE" = "false" ]; then
   echo "Everything is up to date."
@@ -23,18 +31,15 @@ fi
 echo ""
 echo "=== Applying updates ==="
 
-# Update go.mod minimum version
-sed -i.bak "s/^go .*/go ${GO_PREV}.0/" go.mod && rm -f go.mod.bak
+# Update go.mod minimum version and tidy
+go mod tidy -go="${GO_PREV}.0"
 echo "Updated go.mod: go ${GO_PREV}.0"
 
-# Update go.yaml TinyGo matrix: Go version and TinyGo versions
+# Update .github/workflows/go.yaml TinyGo matrix: Go version and TinyGo versions
 sed -i.bak "s/big: \"${CUR_BIG}\"/big: \"${TINYGO_GO}\"/g" .github/workflows/go.yaml && rm -f .github/workflows/go.yaml.bak
 sed -i.bak "s/tiny: \"${CUR_TINY_PREV}\"/tiny: \"${TINYGO_PREV}\"/g" .github/workflows/go.yaml && rm -f .github/workflows/go.yaml.bak
 sed -i.bak "s/tiny: \"${CUR_TINY_LATEST}\"/tiny: \"${TINYGO_LATEST}\"/g" .github/workflows/go.yaml && rm -f .github/workflows/go.yaml.bak
-echo "Updated go.yaml: Go ${TINYGO_GO}, TinyGo ${TINYGO_PREV}/${TINYGO_LATEST}"
-
-go mod tidy
-echo "Ran go mod tidy"
+echo "Updated .github/workflows/go.yaml: Go ${TINYGO_GO}, TinyGo ${TINYGO_PREV}/${TINYGO_LATEST}"
 
 echo ""
 echo "Done. Review changes with: git diff"

--- a/scripts/go-versions-update.sh
+++ b/scripts/go-versions-update.sh
@@ -12,8 +12,8 @@ cd "$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 
 # Run check script and extract KEY=VALUE pairs
 CHECK_OUTPUT=$("$SCRIPT_DIR/go-versions-check.sh" 2>&1) || true
-echo "$CHECK_OUTPUT" | grep -v '^[A-Z_]*='
-eval "$(echo "$CHECK_OUTPUT" | grep '^[A-Z_]*=')"
+echo "$CHECK_OUTPUT" | grep -v '^[A-Z_][A-Z_]*='
+eval "$(echo "$CHECK_OUTPUT" | grep '^[A-Z_][A-Z_]*=')"
 
 if [ "$NEEDS_UPDATE" = "false" ]; then
   echo "Everything is up to date."

--- a/scripts/go-versions-update.sh
+++ b/scripts/go-versions-update.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Update Go and TinyGo versions in go.mod and go.yaml.
+# Runs go-versions-check.sh first to detect required versions.
+#
+# Requires: curl, jq, gh (authenticated), sed, go
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+# Run check script and extract KEY=VALUE pairs
+CHECK_OUTPUT=$("$SCRIPT_DIR/go-versions-check.sh" 2>&1) || true
+echo "$CHECK_OUTPUT" | grep -v '^[A-Z_]*='
+eval "$(echo "$CHECK_OUTPUT" | grep '^[A-Z_]*=')"
+
+if [ "$NEEDS_UPDATE" = "false" ]; then
+  echo "Everything is up to date."
+  exit 0
+fi
+
+echo ""
+echo "=== Applying updates ==="
+
+# Update go.mod minimum version
+sed -i.bak "s/^go .*/go ${GO_PREV}.0/" go.mod && rm -f go.mod.bak
+echo "Updated go.mod: go ${GO_PREV}.0"
+
+# Update go.yaml TinyGo matrix: Go version and TinyGo versions
+sed -i.bak "s/big: \"${CUR_BIG}\"/big: \"${TINYGO_GO}\"/g" .github/workflows/go.yaml && rm -f .github/workflows/go.yaml.bak
+sed -i.bak "s/tiny: \"${CUR_TINY_PREV}\"/tiny: \"${TINYGO_PREV}\"/g" .github/workflows/go.yaml && rm -f .github/workflows/go.yaml.bak
+sed -i.bak "s/tiny: \"${CUR_TINY_LATEST}\"/tiny: \"${TINYGO_LATEST}\"/g" .github/workflows/go.yaml && rm -f .github/workflows/go.yaml.bak
+echo "Updated go.yaml: Go ${TINYGO_GO}, TinyGo ${TINYGO_PREV}/${TINYGO_LATEST}"
+
+go mod tidy
+echo "Ran go mod tidy"
+
+echo ""
+echo "Done. Review changes with: git diff"


### PR DESCRIPTION
Adds scripts and corresponding CI workflow, for checking and updating the Go and TinyGo versions.

Historically, our Dependabot jobs break whenever the gap between these current and previous versions gets too wide. This is an attempt to automate away the annoyance.

Example output:

```
$ make go-versions-check

=== Go & TinyGo Version Check ===
Go stable releases:  1.25, 1.26
TinyGo releases:     0.39.0, 0.40.1 (supports up to Go 1.25)

go.mod minimum:      1.24.10 -> 1.25.0
go.yaml Go (TinyGo): 1.24 -> 1.25
go.yaml TinyGo:      0.36.0, 0.37.0 -> 0.39.0, 0.40.1

Needs update: true

GO_PREV=1.25
TINYGO_GO=1.25
TINYGO_PREV=0.39.0
TINYGO_LATEST=0.40.1
CUR_BIG=1.24
CUR_TINY_PREV=0.36.0
CUR_TINY_LATEST=0.37.0
NEEDS_UPDATE=true
```

And a few other things:

- Added `cmd/lint` so that we can lint all the things
- Addressed linting issues that the script surfaced
- Added linting config files