### PR TITLE
Address the NS metadata flapping issue

### DIFF
--- a/internal/build/dns.go
+++ b/internal/build/dns.go
@@ -143,6 +143,7 @@ func FetchNameServers(zones, allZones map[string]*Zone) error {
 
 		// Iterate over name servers
 		counts := make(map[string]int, 8)
+		successfulResponses := 0 // parents that returned a valid DNS response (NOERROR or NXDOMAIN), not network failures
 		for _, host := range parentNS {
 			if _, ok := nx.Load(host); ok {
 				continue
@@ -173,6 +174,7 @@ func FetchNameServers(zones, allZones map[string]*Zone) error {
 				// }
 				continue
 			}
+			successfulResponses++
 			if rmsg.Rcode == dns.RcodeNameError {
 				// color.Fprintf(os.Stderr, "@{y}Warning: %s returned NXDOMAIN for %s (NS)\n", host, z.Domain)
 				continue
@@ -215,8 +217,12 @@ func FetchNameServers(zones, allZones map[string]*Zone) error {
 			atomic.AddInt32(&found, 1)
 		}
 
-		// Sanity check
-		if len(z.NameServers) == 0 && len(z.oldNameServers) > 0 {
+		// If every parent query failed at the network layer, keep prior NS list.
+		// Authoritative NXDOMAIN/NOERROR responses still clear the list.
+		if len(z.NameServers) == 0 && len(z.oldNameServers) > 0 && successfulResponses == 0 {
+			z.NameServers = z.oldNameServers
+			color.Fprintf(os.Stderr, "@{y}All parent queries failed for %s, keeping previous NS list@{y}\n", z)
+		} else if len(z.NameServers) == 0 && len(z.oldNameServers) > 0 {
 			color.Fprintf(os.Stderr, "@{y}Zone lost all name servers: @{y!}%s@{y}\n", z)
 		}
 

--- a/internal/build/dns.go
+++ b/internal/build/dns.go
@@ -201,9 +201,9 @@ func FetchNameServers(zones, allZones map[string]*Zone) error {
 
 		// Store new name servers
 		for ns, count := range counts {
-			// Ignore non-consensus values where > 1 name server does not return ns
-			// FIXME: this criteria is subjective)
-			if count == 1 && max > 2 {
+			// Drop non-consensus NSs (count=1 while max>2), UNLESS the NS was
+			// previously trusted — mirrors FetchRootZone's "keep if known" rule.
+			if count == 1 && max > 2 && !slices.Contains(z.oldNameServers, ns) {
 				color.Fprintf(os.Stderr, "@{y}Warning: non-consensus name server for %s: %s (%d < %d)\n", z, ns, count, max)
 				atomic.AddInt32(&skipped, 1)
 				continue

--- a/internal/build/dns.go
+++ b/internal/build/dns.go
@@ -382,7 +382,11 @@ func randLabel(n int) string {
 	return string(b)
 }
 
-func exchange(ctx context.Context, host, qname string, qtype uint16) (*dns.Msg, error) {
+// exchange performs a DNS query against host for qname/qtype. It is a
+// package-level var so tests can substitute a scripted implementation.
+var exchange = defaultExchange
+
+func defaultExchange(ctx context.Context, host, qname string, qtype uint16) (*dns.Msg, error) {
 	qmsg := &dns.Msg{}
 	qmsg.RecursionDesired = true
 	qmsg.SetQuestion(dns.Fqdn(qname), qtype)

--- a/internal/build/dns_test.go
+++ b/internal/build/dns_test.go
@@ -1,0 +1,106 @@
+package build
+
+import (
+	"context"
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// scriptedExchange builds a drop-in replacement for the package-level exchange
+// var, used by tests to return canned DNS responses per parent hostname.
+func scriptedExchange(t *testing.T, scenarios map[string]scriptedResponse) func(ctx context.Context, host, qname string, qtype uint16) (*dns.Msg, error) {
+	t.Helper()
+	return func(ctx context.Context, host, qname string, qtype uint16) (*dns.Msg, error) {
+		s, ok := scenarios[host]
+		if !ok {
+			t.Fatalf("scriptedExchange: unexpected host %q", host)
+		}
+		if s.timeout {
+			return nil, context.DeadlineExceeded
+		}
+		msg := &dns.Msg{}
+		msg.SetQuestion(dns.Fqdn(qname), qtype)
+		msg.Response = true
+		msg.Rcode = s.rcode
+		for _, ns := range s.nsRecords {
+			msg.Ns = append(msg.Ns, &dns.NS{
+				Hdr: dns.RR_Header{Name: dns.Fqdn(qname), Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 3600},
+				Ns:  dns.Fqdn(ns),
+			})
+		}
+		return msg, nil
+	}
+}
+
+type scriptedResponse struct {
+	timeout   bool
+	rcode     int
+	nsRecords []string
+}
+
+func sorted(s []string) []string {
+	out := slices.Clone(s)
+	sort.Strings(out)
+	return out
+}
+
+// TestFetchNameServers_AllParentsTimeOut verifies that when every parent NS
+// query fails at the network layer, the zone's prior NS list is preserved.
+// This is the regression guard for the nightly-metadata flap.
+func TestFetchNameServers_AllParentsTimeOut(t *testing.T) {
+	prior := []string{"ns-a.example", "ns-b.example"}
+	parent := &Zone{Domain: "tld", NameServers: []string{"p1", "p2", "p3", "p4", "p5"}}
+	child := &Zone{Domain: "example.tld", NameServers: slices.Clone(prior)}
+	allZones := map[string]*Zone{"tld": parent, "example.tld": child}
+
+	origExchange := exchange
+	t.Cleanup(func() { exchange = origExchange })
+	exchange = scriptedExchange(t, map[string]scriptedResponse{
+		"p1": {timeout: true},
+		"p2": {timeout: true},
+		"p3": {timeout: true},
+		"p4": {timeout: true},
+		"p5": {timeout: true},
+	})
+
+	if err := FetchNameServers(map[string]*Zone{"example.tld": child}, allZones); err != nil {
+		t.Fatalf("FetchNameServers returned error: %v", err)
+	}
+
+	got := sorted(child.NameServers)
+	want := sorted(prior)
+	if !slices.Equal(got, want) {
+		t.Errorf("NS list should be preserved when all parents fail; got %v, want %v", got, want)
+	}
+}
+
+// TestFetchNameServers_AllParentsReturnNXDOMAIN verifies that when every
+// parent authoritatively reports the zone as nonexistent, the NS list is
+// cleared (not preserved). This guards against immortalizing retired zones.
+func TestFetchNameServers_AllParentsReturnNXDOMAIN(t *testing.T) {
+	prior := []string{"ns-a.example", "ns-b.example"}
+	parent := &Zone{Domain: "tld", NameServers: []string{"p1", "p2", "p3", "p4", "p5"}}
+	child := &Zone{Domain: "example.tld", NameServers: slices.Clone(prior)}
+	allZones := map[string]*Zone{"tld": parent, "example.tld": child}
+
+	origExchange := exchange
+	t.Cleanup(func() { exchange = origExchange })
+	exchange = scriptedExchange(t, map[string]scriptedResponse{
+		"p1": {rcode: dns.RcodeNameError},
+		"p2": {rcode: dns.RcodeNameError},
+		"p3": {rcode: dns.RcodeNameError},
+		"p4": {rcode: dns.RcodeNameError},
+		"p5": {rcode: dns.RcodeNameError},
+	})
+
+	if err := FetchNameServers(map[string]*Zone{"example.tld": child}, allZones); err != nil {
+		t.Fatalf("FetchNameServers returned error: %v", err)
+	}
+
+	if len(child.NameServers) != 0 {
+		t.Errorf("NS list should be cleared on authoritative NXDOMAIN; got %v", child.NameServers)
+	}
+}

--- a/internal/build/dns_test.go
+++ b/internal/build/dns_test.go
@@ -104,3 +104,33 @@ func TestFetchNameServers_AllParentsReturnNXDOMAIN(t *testing.T) {
 		t.Errorf("NS list should be cleared on authoritative NXDOMAIN; got %v", child.NameServers)
 	}
 }
+
+// TestFetchNameServers_PreviouslyKnownNSSurvivesPartialDisagreement verifies
+// that an NS previously in the zone's list is not dropped by the consensus
+// filter just because only one parent happens to return it in a given run.
+func TestFetchNameServers_PreviouslyKnownNSSurvivesPartialDisagreement(t *testing.T) {
+	prior := []string{"ns-a.example", "ns-b.example", "ns-extra.example"}
+	parent := &Zone{Domain: "tld", NameServers: []string{"p1", "p2", "p3", "p4", "p5"}}
+	child := &Zone{Domain: "example.tld", NameServers: slices.Clone(prior)}
+	allZones := map[string]*Zone{"tld": parent, "example.tld": child}
+
+	origExchange := exchange
+	t.Cleanup(func() { exchange = origExchange })
+	exchange = scriptedExchange(t, map[string]scriptedResponse{
+		"p1": {nsRecords: []string{"ns-a.example", "ns-b.example"}},
+		"p2": {nsRecords: []string{"ns-a.example", "ns-b.example"}},
+		"p3": {nsRecords: []string{"ns-a.example", "ns-b.example"}},
+		"p4": {nsRecords: []string{"ns-a.example", "ns-b.example"}},
+		"p5": {nsRecords: []string{"ns-a.example", "ns-b.example", "ns-extra.example"}},
+	})
+
+	if err := FetchNameServers(map[string]*Zone{"example.tld": child}, allZones); err != nil {
+		t.Fatalf("FetchNameServers returned error: %v", err)
+	}
+
+	got := sorted(child.NameServers)
+	want := sorted([]string{"ns-a.example", "ns-b.example", "ns-extra.example"})
+	if !slices.Equal(got, want) {
+		t.Errorf("previously-known NS should not be dropped by consensus filter; got %v, want %v", got, want)
+	}
+}

--- a/internal/build/dns_test.go
+++ b/internal/build/dns_test.go
@@ -105,10 +105,11 @@ func TestFetchNameServers_AllParentsReturnNXDOMAIN(t *testing.T) {
 	}
 }
 
-// TestFetchNameServers_PreviouslyKnownNSSurvivesPartialDisagreement verifies
-// that an NS previously in the zone's list is not dropped by the consensus
-// filter just because only one parent happens to return it in a given run.
-func TestFetchNameServers_PreviouslyKnownNSSurvivesPartialDisagreement(t *testing.T) {
+// Verifies that a previously-known NS still returned by at least one
+// parent survives the consensus filter, even when count==1 and max>2.
+// An NS absent from every parent response is dropped by a different
+// codepath, not exercised here.
+func TestFetchNameServers_ConsensusFilterKeepsKnownNS(t *testing.T) {
 	prior := []string{"ns-a.example", "ns-b.example", "ns-extra.example"}
 	parent := &Zone{Domain: "tld", NameServers: []string{"p1", "p2", "p3", "p4", "p5"}}
 	child := &Zone{Domain: "example.tld", NameServers: slices.Clone(prior)}


### PR DESCRIPTION
I noticed in the nightly ZoneDB auto-updates ([example](https://github.com/zonedb/zonedb/commit/e935695c510dd7fd406ca7defbb44534604e530c)) that many of the SLD metadata files are "flapping" each day - their values are toggling back and forth. It seemed like a possible bug worth looking into, which led to this PR's test and fix.