### PR TITLE
Nightly updates - add -verify-ns

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -6,7 +6,7 @@ on:
       zonedbArgs:
         description: "zonedb arguments"
         required: false
-        default: "-verify-whois"
+        default: "-verify-whois -verify-ns"
   schedule:
     - cron: "07 8 * * *" # 08:07 UTC, or 12:07 AM PT
 
@@ -48,7 +48,10 @@ jobs:
 
       - name: Update ZoneDB
         env:
-          ZONEDB_ARGS: ${{ github.event.inputs.zonedbArgs }}
+          # On schedule events, inputs.zonedbArgs is empty; fall back to the
+          # same defaults as the workflow_dispatch input so the nightly run
+          # also performs whois and nameserver verification.
+          ZONEDB_ARGS: ${{ github.event.inputs.zonedbArgs || '-verify-whois -verify-ns' }}
         run: make update
 
       - name: Vet Go code


### PR DESCRIPTION
This will prune stale NS data from the metadata files.

I ran this locally while testing, and it found a handful. The first time this runs in CI will probably be a larger data update, then it the changes should quiet down afterward.