### PR TITLE
NS record flapping - add more DNS logging

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -52,6 +52,11 @@ jobs:
           # same defaults as the workflow_dispatch input so the nightly run
           # also performs whois and nameserver verification.
           ZONEDB_ARGS: ${{ github.event.inputs.zonedbArgs || '-verify-whois -verify-ns' }}
+          # Temporary: capture per-zone NS fetch/verify diagnostics for the
+          # .рус flap investigation. Remove once the root cause is identified.
+          # See temp/Plans/2026-05-NS-flapping/.
+          ZONEDB_DEBUG_NS: "1"
+          ZONEDB_DEBUG_NS_SUFFIX: "рус"
         run: make update
 
       - name: Vet Go code

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -34,10 +34,8 @@ jobs:
       - name: Get go dependencies
         run: go get -t ./...
 
-      # Since github.run_id makes the primary cache key unique per run,
-      # this step will usually restore .cache/ via the restore-keys:
-      # etag-cache- prefix (latest match), then save a new snapshot
-      # under the run-specific key for future runs.
+      # Primary key is unique per run, so restore falls back to the latest
+      # etag-cache- prefix match and saves a new run-specific snapshot.
       - name: Restore ETag cache
         uses: actions/cache@v5
         with:
@@ -48,13 +46,9 @@ jobs:
 
       - name: Update ZoneDB
         env:
-          # On schedule events, inputs.zonedbArgs is empty; fall back to the
-          # same defaults as the workflow_dispatch input so the nightly run
-          # also performs whois and nameserver verification.
+          # Default to the workflow_dispatch input's default for scheduled runs.
           ZONEDB_ARGS: ${{ github.event.inputs.zonedbArgs || '-verify-whois -verify-ns' }}
-          # Temporary: capture per-zone NS fetch/verify diagnostics for the
-          # .рус flap investigation. Remove once the root cause is identified.
-          # See temp/Plans/2026-05-NS-flapping/.
+          # Temporary NS flap diagnostics; remove once the root cause is found.
           ZONEDB_DEBUG_NS: "1"
           ZONEDB_DEBUG_NS_SUFFIX: "рус"
         run: make update

--- a/internal/build/dns.go
+++ b/internal/build/dns.go
@@ -121,6 +121,7 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 	color.Fprintf(os.Stderr, "@{.}Fetching name servers for %d zone(s)...\n", len(zones))
 	var nx sync.Map
 	var found, added, removed, skipped, failed, unresolved int32
+	resetParentStats()
 	err := mapZones(ctx, zones, func(gctx context.Context, z *Zone) error {
 		// Skip TLDs
 		if z.IsTLD() {
@@ -147,6 +148,11 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 		// Iterate over name servers
 		counts := make(map[string]int, 8)
 		successfulResponses := 0 // parents that returned a valid DNS response (NOERROR or NXDOMAIN), not network failures
+		// Populated only when ZONEDB_DEBUG_NS is set.
+		var perParent []parentObservation
+		if nsDebugEnabled() {
+			perParent = make([]parentObservation, 0, len(parentNS))
+		}
 		for _, host := range parentNS {
 			// Short-circuit on cancellation. Without this, the callback would fall
 			// off the end returning nil and errgroup wouldn't see the cancellation.
@@ -163,9 +169,17 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 				var to timeouter
 				if errors.As(err, &to) && to.Timeout() {
 					Trace("@{.}Timeout querying %s for @{!}%s@{.}: %s\n", host, z, err.Error())
+					recordParentStat(host, parentOutcomeTimeout)
+					if perParent != nil {
+						perParent = append(perParent, parentObservation{host: host, outcome: "timeout", errMsg: err.Error()})
+					}
 					continue
 				}
 				color.Fprintf(os.Stderr, "@{r}Error querying %s for @{r!}%s@{r}: %s\n", host, z, err.Error())
+				recordParentStat(host, parentOutcomeOtherErr)
+				if perParent != nil {
+					perParent = append(perParent, parentObservation{host: host, outcome: "err", errMsg: err.Error()})
+				}
 
 				// Cache host not found
 				if strings.Contains(err.Error(), "no such host") {
@@ -190,16 +204,26 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 				// Expected. Many parent NS don't serve the child zone authoritatively. Uncomment to debug.
 				//
 				// color.Fprintf(os.Stderr, "@{y}Warning: %s returned NXDOMAIN for %s (NS)\n", host, z.Domain)
+				recordParentStat(host, parentOutcomeNXDOMAIN)
+				if perParent != nil {
+					perParent = append(perParent, parentObservation{host: host, outcome: "nxdomain"})
+				}
 				continue
 			}
+			nsReturned := 0
 			for _, rr := range append(rmsg.Answer, rmsg.Ns...) {
 				if ns, ok := rr.(*dns.NS); ok {
 					v := Normalize(ns.Ns)
 					counts[v] = counts[v] + 1
+					nsReturned++
 					// Uncomment to trace which parent NS returned which child NS record.
 					//
 					// color.Fprintf(os.Stderr, "@{.}DNS record for %s: %s\n", z.Domain, v)
 				}
+			}
+			recordParentStat(host, parentOutcomeNOERROR)
+			if perParent != nil {
+				perParent = append(perParent, parentObservation{host: host, outcome: "noerror", nsReturned: nsReturned})
 			}
 		}
 
@@ -240,11 +264,20 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 
 		// If every parent query failed at the network layer, keep prior NS list.
 		// Authoritative NXDOMAIN/NOERROR responses still clear the list.
+		branch := fetchBranchChanged
 		if len(z.NameServers) == 0 && len(z.oldNameServers) > 0 && successfulResponses == 0 {
 			z.NameServers = z.oldNameServers
 			color.Fprintf(os.Stderr, "@{y}All parent queries failed for %s, keeping previous NS list@{y}\n", z)
+			branch = fetchBranchPreservedAllFailed
 		} else if len(z.NameServers) == 0 && len(z.oldNameServers) > 0 {
 			color.Fprintf(os.Stderr, "@{y}Zone lost all name servers: @{y!}%s@{y}\n", z)
+			branch = fetchBranchLostAllNS
+		} else if slicesEqualUnordered(z.oldNameServers, z.NameServers) {
+			branch = fetchBranchUnchanged
+		}
+
+		if perParent != nil {
+			emitFetchObservation(z, parentNS, perParent, counts, successfulResponses, branch)
 		}
 
 		// Record changes
@@ -263,6 +296,7 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 		return nil
 	})
 	color.Fprintf(os.Stderr, "@{.}\nFound %d name servers, %d added, %d removed, %d non-consensus, %d failed, %d NXDOMAIN\n", found, added, removed, skipped, failed, unresolved)
+	emitParentStats()
 	return err
 }
 
@@ -272,17 +306,35 @@ func VerifyNameServers(ctx context.Context, zones map[string]*Zone) error {
 	color.Fprintf(os.Stderr, "@{.}Verifying name servers for %d zones...\n", len(zones))
 	return mapZones(ctx, zones, func(gctx context.Context, z *Zone) error {
 		var nameServers []string
+		var perNS []nsVerifyObservation
+		if nsDebugEnabled() {
+			perNS = make([]nsVerifyObservation, 0, len(z.NameServers))
+		}
+		prior := slices.Clone(z.NameServers)
 		for _, ns := range z.NameServers {
 			if err := verifyNS(gctx, ns); err != nil {
 				if gctx.Err() != nil {
 					return gctx.Err()
 				}
 				LogWarning(fmt.Errorf("can’t verify name server %s: %s", ns, err))
+				if perNS != nil {
+					perNS = append(perNS, nsVerifyObservation{ns: ns, errMsg: err.Error()})
+				}
 			} else {
 				nameServers = append(nameServers, ns)
+				if perNS != nil {
+					perNS = append(perNS, nsVerifyObservation{ns: ns})
+				}
 			}
 		}
 		z.NameServers = nameServers
+		if perNS != nil {
+			branch := verifyBranchUnchanged
+			if !slicesEqualUnordered(prior, z.NameServers) {
+				branch = verifyBranchDropped
+			}
+			emitVerifyObservation(z, prior, perNS, branch)
+		}
 		return nil
 	})
 }

--- a/internal/build/dns.go
+++ b/internal/build/dns.go
@@ -121,7 +121,7 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 	color.Fprintf(os.Stderr, "@{.}Fetching name servers for %d zone(s)...\n", len(zones))
 	var nx sync.Map
 	var found, added, removed, skipped, failed, unresolved int32
-	resetParentStats()
+	debugger := newNSDebugger()
 	err := mapZones(ctx, zones, func(gctx context.Context, z *Zone) error {
 		// Skip TLDs
 		if z.IsTLD() {
@@ -148,11 +148,7 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 		// Iterate over name servers
 		counts := make(map[string]int, 8)
 		successfulResponses := 0 // parents that returned a valid DNS response (NOERROR or NXDOMAIN), not network failures
-		// Populated only when ZONEDB_DEBUG_NS is set.
-		var perParent []parentObservation
-		if nsDebugEnabled() {
-			perParent = make([]parentObservation, 0, len(parentNS))
-		}
+		observer := debugger.ForFetchZone(z, len(parentNS))
 		for _, host := range parentNS {
 			// Short-circuit on cancellation. Without this, the callback would fall
 			// off the end returning nil and errgroup wouldn't see the cancellation.
@@ -169,17 +165,11 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 				var to timeouter
 				if errors.As(err, &to) && to.Timeout() {
 					Trace("@{.}Timeout querying %s for @{!}%s@{.}: %s\n", host, z, err.Error())
-					recordParentStat(host, parentOutcomeTimeout)
-					if perParent != nil {
-						perParent = append(perParent, parentObservation{host: host, outcome: "timeout", errMsg: err.Error()})
-					}
+					observer.ObserveParent(parentObservation{host: host, outcome: parentOutcomeTimeout, errMsg: err.Error()})
 					continue
 				}
 				color.Fprintf(os.Stderr, "@{r}Error querying %s for @{r!}%s@{r}: %s\n", host, z, err.Error())
-				recordParentStat(host, parentOutcomeOtherErr)
-				if perParent != nil {
-					perParent = append(perParent, parentObservation{host: host, outcome: "err", errMsg: err.Error()})
-				}
+				observer.ObserveParent(parentObservation{host: host, outcome: parentOutcomeOtherErr, errMsg: err.Error()})
 
 				// Cache host not found
 				if strings.Contains(err.Error(), "no such host") {
@@ -204,10 +194,7 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 				// Expected. Many parent NS don't serve the child zone authoritatively. Uncomment to debug.
 				//
 				// color.Fprintf(os.Stderr, "@{y}Warning: %s returned NXDOMAIN for %s (NS)\n", host, z.Domain)
-				recordParentStat(host, parentOutcomeNXDOMAIN)
-				if perParent != nil {
-					perParent = append(perParent, parentObservation{host: host, outcome: "nxdomain"})
-				}
+				observer.ObserveParent(parentObservation{host: host, outcome: parentOutcomeNXDOMAIN})
 				continue
 			}
 			nsReturned := 0
@@ -221,10 +208,7 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 					// color.Fprintf(os.Stderr, "@{.}DNS record for %s: %s\n", z.Domain, v)
 				}
 			}
-			recordParentStat(host, parentOutcomeNOERROR)
-			if perParent != nil {
-				perParent = append(perParent, parentObservation{host: host, outcome: "noerror", nsReturned: nsReturned})
-			}
+			observer.ObserveParent(parentObservation{host: host, outcome: parentOutcomeNOERROR, nsReturned: nsReturned})
 		}
 
 		// Get max (consensus) count
@@ -276,9 +260,7 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 			branch = fetchBranchUnchanged
 		}
 
-		if perParent != nil {
-			emitFetchObservation(z, parentNS, perParent, counts, successfulResponses, branch)
-		}
+		observer.EmitFetch(parentNS, counts, successfulResponses, branch)
 
 		// Record changes
 		olds := NewSet(z.oldNameServers...)
@@ -296,7 +278,7 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 		return nil
 	})
 	color.Fprintf(os.Stderr, "@{.}\nFound %d name servers, %d added, %d removed, %d non-consensus, %d failed, %d NXDOMAIN\n", found, added, removed, skipped, failed, unresolved)
-	emitParentStats()
+	debugger.EmitParentStats()
 	return err
 }
 
@@ -304,37 +286,29 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 // Per-zone verification failures are logged and the failing entries dropped.
 func VerifyNameServers(ctx context.Context, zones map[string]*Zone) error {
 	color.Fprintf(os.Stderr, "@{.}Verifying name servers for %d zones...\n", len(zones))
+	debugger := newNSDebugger()
 	return mapZones(ctx, zones, func(gctx context.Context, z *Zone) error {
 		var nameServers []string
-		var perNS []nsVerifyObservation
-		if nsDebugEnabled() {
-			perNS = make([]nsVerifyObservation, 0, len(z.NameServers))
-		}
 		prior := slices.Clone(z.NameServers)
+		observer := debugger.ForVerifyZone(z, prior)
 		for _, ns := range z.NameServers {
-			if err := verifyNS(gctx, ns); err != nil {
+			err := verifyNS(gctx, ns)
+			if err != nil {
 				if gctx.Err() != nil {
 					return gctx.Err()
 				}
 				LogWarning(fmt.Errorf("can’t verify name server %s: %s", ns, err))
-				if perNS != nil {
-					perNS = append(perNS, nsVerifyObservation{ns: ns, errMsg: err.Error()})
-				}
 			} else {
 				nameServers = append(nameServers, ns)
-				if perNS != nil {
-					perNS = append(perNS, nsVerifyObservation{ns: ns})
-				}
 			}
+			observer.ObserveNS(ns, err)
 		}
 		z.NameServers = nameServers
-		if perNS != nil {
-			branch := verifyBranchUnchanged
-			if !slicesEqualUnordered(prior, z.NameServers) {
-				branch = verifyBranchDropped
-			}
-			emitVerifyObservation(z, prior, perNS, branch)
+		branch := verifyBranchUnchanged
+		if !slicesEqualUnordered(prior, z.NameServers) {
+			branch = verifyBranchDropped
 		}
+		observer.EmitVerify(branch)
 		return nil
 	})
 }

--- a/internal/build/dns_debug.go
+++ b/internal/build/dns_debug.go
@@ -1,0 +1,278 @@
+package build
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/wsxiaoys/terminal/color"
+)
+
+// NS debug logging.
+//
+// Enabled by setting ZONEDB_DEBUG_NS in the environment. Emits three kinds
+// of lines to stderr:
+//
+//	NS_CHANGE step=fetch|verify  per-zone, only when the NS list changed.
+//	NS_TRACE  step=fetch|verify  per-zone, always, but only for zones whose
+//	                             domain matches one of the suffixes in
+//	                             ZONEDB_DEBUG_NS_SUFFIX (comma-separated).
+//	                             Used to capture "healthy" runs for
+//	                             comparison against wipe runs.
+//	PARENT_STATS                 one line per distinct parent host queried,
+//	                             emitted at the end of FetchNameServers.
+//
+// Every emit includes a branch= tag identifying which code path fired, so the
+// log can be grepped for specific preservation/removal behavior.
+//
+// Zero cost when ZONEDB_DEBUG_NS is unset. sync.Once caches the lookup, all
+// record/emit helpers early-return.
+
+type parentOutcome int
+
+const (
+	parentOutcomeNOERROR parentOutcome = iota
+	parentOutcomeNXDOMAIN
+	parentOutcomeTimeout
+	parentOutcomeOtherErr
+)
+
+// fetchBranch tags which preservation/removal path fired in FetchNameServers.
+type fetchBranch string
+
+const (
+	fetchBranchUnchanged          fetchBranch = "unchanged"            // old == new
+	fetchBranchChanged            fetchBranch = "changed"              // normal update
+	fetchBranchPreservedAllFailed fetchBranch = "preserved-all-failed" // PR #1124 escape hatch: successfulResponses==0
+	fetchBranchLostAllNS          fetchBranch = "lost-all-ns"          // cleared despite having prior NS
+)
+
+// verifyBranch tags which path fired in VerifyNameServers.
+type verifyBranch string
+
+const (
+	verifyBranchUnchanged verifyBranch = "unchanged"
+	verifyBranchDropped   verifyBranch = "dropped"
+)
+
+type parentObservation struct {
+	host       string
+	outcome    string // "noerror" | "nxdomain" | "timeout" | "err"
+	errMsg     string
+	nsReturned int
+}
+
+type nsVerifyObservation struct {
+	ns     string
+	errMsg string // empty means verification succeeded
+}
+
+type parentStatRow struct {
+	queries, noerror, nxdomain, timeout, otherErr int
+}
+
+var (
+	nsDebugOnce     sync.Once
+	nsDebugOn       bool
+	nsDebugSuffixes []string
+
+	parentStatsMu sync.Mutex
+	parentStats   = map[string]*parentStatRow{}
+)
+
+// nsDebugEnabled reports whether debug logging is on. Cached after first call.
+func nsDebugEnabled() bool {
+	nsDebugOnce.Do(func() {
+		nsDebugOn = os.Getenv("ZONEDB_DEBUG_NS") != ""
+		if s := os.Getenv("ZONEDB_DEBUG_NS_SUFFIX"); s != "" {
+			for _, part := range strings.Split(s, ",") {
+				part = strings.TrimSpace(part)
+				if part != "" {
+					nsDebugSuffixes = append(nsDebugSuffixes, part)
+				}
+			}
+		}
+	})
+	return nsDebugOn
+}
+
+// nsDebugMatchesTraceSuffix reports whether a zone domain is covered by the
+// always-on NS_TRACE logging, based on ZONEDB_DEBUG_NS_SUFFIX. Returns false
+// when no suffix is configured or when the domain matches none of them.
+func nsDebugMatchesTraceSuffix(domain string) bool {
+	if !nsDebugEnabled() || len(nsDebugSuffixes) == 0 {
+		return false
+	}
+	for _, suf := range nsDebugSuffixes {
+		if strings.HasSuffix(domain, suf) {
+			return true
+		}
+	}
+	return false
+}
+
+func resetParentStats() {
+	parentStatsMu.Lock()
+	defer parentStatsMu.Unlock()
+	parentStats = map[string]*parentStatRow{}
+}
+
+func recordParentStat(host string, outcome parentOutcome) {
+	if !nsDebugEnabled() {
+		return
+	}
+	parentStatsMu.Lock()
+	defer parentStatsMu.Unlock()
+	row := parentStats[host]
+	if row == nil {
+		row = &parentStatRow{}
+		parentStats[host] = row
+	}
+	row.queries++
+	switch outcome {
+	case parentOutcomeNOERROR:
+		row.noerror++
+	case parentOutcomeNXDOMAIN:
+		row.nxdomain++
+	case parentOutcomeTimeout:
+		row.timeout++
+	case parentOutcomeOtherErr:
+		row.otherErr++
+	}
+}
+
+func emitParentStats() {
+	if !nsDebugEnabled() {
+		return
+	}
+	// Snapshot under a single lock, then sort and emit without holding it.
+	parentStatsMu.Lock()
+	snapshot := make(map[string]parentStatRow, len(parentStats))
+	for h, r := range parentStats {
+		snapshot[h] = *r
+	}
+	parentStatsMu.Unlock()
+
+	hosts := make([]string, 0, len(snapshot))
+	for h := range snapshot {
+		hosts = append(hosts, h)
+	}
+	sort.Strings(hosts)
+	for _, h := range hosts {
+		r := snapshot[h]
+		color.Fprintf(os.Stderr, "PARENT_STATS host=%s queries=%d noerror=%d nxdomain=%d timeout=%d other_err=%d\n",
+			h, r.queries, r.noerror, r.nxdomain, r.timeout, r.otherErr)
+	}
+}
+
+// emitFetchObservation is called once per zone after FetchNameServers has
+// finished processing it. Emits NS_CHANGE for changed zones, NS_TRACE for
+// zones matching ZONEDB_DEBUG_NS_SUFFIX regardless of change.
+func emitFetchObservation(
+	z *Zone,
+	parentNS []string,
+	obs []parentObservation,
+	counts map[string]int,
+	successful int,
+	branch fetchBranch,
+) {
+	if !nsDebugEnabled() {
+		return
+	}
+	changed := branch != fetchBranchUnchanged
+	trace := nsDebugMatchesTraceSuffix(z.Domain)
+	if !changed && !trace {
+		return
+	}
+	kind := "NS_CHANGE"
+	if !changed {
+		kind = "NS_TRACE"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s step=fetch branch=%s zone=%s old=%s new=%s parents=%d successful=%d counts=%s\n",
+		kind, branch, z.Domain,
+		formatNSList(z.oldNameServers), formatNSList(z.NameServers),
+		len(parentNS), successful, formatCounts(counts))
+	for _, o := range obs {
+		switch o.outcome {
+		case "noerror":
+			fmt.Fprintf(&b, "  parent=%s outcome=noerror ns_returned=%d\n", o.host, o.nsReturned)
+		case "nxdomain":
+			fmt.Fprintf(&b, "  parent=%s outcome=nxdomain\n", o.host)
+		case "timeout":
+			fmt.Fprintf(&b, "  parent=%s outcome=timeout err=%q\n", o.host, o.errMsg)
+		case "err":
+			fmt.Fprintf(&b, "  parent=%s outcome=err err=%q\n", o.host, o.errMsg)
+		}
+	}
+	color.Fprintf(os.Stderr, "%s", b.String())
+}
+
+// emitVerifyObservation is the Verify-step analog of emitFetchObservation.
+func emitVerifyObservation(
+	z *Zone,
+	prior []string,
+	obs []nsVerifyObservation,
+	branch verifyBranch,
+) {
+	if !nsDebugEnabled() {
+		return
+	}
+	changed := branch != verifyBranchUnchanged
+	trace := nsDebugMatchesTraceSuffix(z.Domain)
+	if !changed && !trace {
+		return
+	}
+	kind := "NS_CHANGE"
+	if !changed {
+		kind = "NS_TRACE"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s step=verify branch=%s zone=%s old=%s new=%s\n",
+		kind, branch, z.Domain, formatNSList(prior), formatNSList(z.NameServers))
+	for _, o := range obs {
+		if o.errMsg == "" {
+			fmt.Fprintf(&b, "  ns=%s outcome=ok\n", o.ns)
+		} else {
+			fmt.Fprintf(&b, "  ns=%s outcome=fail err=%q\n", o.ns, o.errMsg)
+		}
+	}
+	color.Fprintf(os.Stderr, "%s", b.String())
+}
+
+func formatNSList(ns []string) string {
+	if len(ns) == 0 {
+		return "[]"
+	}
+	return "[" + strings.Join(ns, ",") + "]"
+}
+
+func formatCounts(counts map[string]int) string {
+	if len(counts) == 0 {
+		return "{}"
+	}
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s:%d", k, counts[k]))
+	}
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
+func slicesEqualUnordered(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := slices.Clone(a)
+	bc := slices.Clone(b)
+	slices.Sort(ac)
+	slices.Sort(bc)
+	return slices.Equal(ac, bc)
+}

--- a/internal/build/dns_debug.go
+++ b/internal/build/dns_debug.go
@@ -11,25 +11,8 @@ import (
 	"github.com/wsxiaoys/terminal/color"
 )
 
-// NS debug logging.
-//
-// Enabled by setting ZONEDB_DEBUG_NS in the environment. Emits three kinds
-// of lines to stderr:
-//
-//	NS_CHANGE step=fetch|verify  per-zone, only when the NS list changed.
-//	NS_TRACE  step=fetch|verify  per-zone, always, but only for zones whose
-//	                             domain matches one of the suffixes in
-//	                             ZONEDB_DEBUG_NS_SUFFIX (comma-separated).
-//	                             Used to capture "healthy" runs for
-//	                             comparison against wipe runs.
-//	PARENT_STATS                 one line per distinct parent host queried,
-//	                             emitted at the end of FetchNameServers.
-//
-// Every emit includes a branch= tag identifying which code path fired, so the
-// log can be grepped for specific preservation/removal behavior.
-//
-// Zero cost when ZONEDB_DEBUG_NS is unset. sync.Once caches the lookup, all
-// record/emit helpers early-return.
+// NS flap debug logging. Gated by ZONEDB_DEBUG_NS; ZONEDB_DEBUG_NS_SUFFIX
+// (comma-separated) additionally emits NS_TRACE for matching zones unchanged.
 
 type parentOutcome int
 
@@ -99,9 +82,8 @@ func nsDebugEnabled() bool {
 	return nsDebugOn
 }
 
-// nsDebugMatchesTraceSuffix reports whether a zone domain is covered by the
-// always-on NS_TRACE logging, based on ZONEDB_DEBUG_NS_SUFFIX. Returns false
-// when no suffix is configured or when the domain matches none of them.
+// nsDebugMatchesTraceSuffix reports whether a zone's domain matches any
+// suffix in ZONEDB_DEBUG_NS_SUFFIX.
 func nsDebugMatchesTraceSuffix(domain string) bool {
 	if !nsDebugEnabled() || len(nsDebugSuffixes) == 0 {
 		return false

--- a/internal/build/dns_debug.go
+++ b/internal/build/dns_debug.go
@@ -23,6 +23,19 @@ const (
 	parentOutcomeOtherErr
 )
 
+// parentOutcomeStrings maps parentOutcome values to log-line labels.
+var parentOutcomeStrings = map[parentOutcome]string{
+	parentOutcomeNOERROR:  "noerror",
+	parentOutcomeNXDOMAIN: "nxdomain",
+	parentOutcomeTimeout:  "timeout",
+	parentOutcomeOtherErr: "err",
+}
+
+// String returns the short label used in NS_CHANGE/NS_TRACE log lines.
+func (o parentOutcome) String() string {
+	return parentOutcomeStrings[o]
+}
+
 // fetchBranch tags which preservation/removal path fired in FetchNameServers.
 type fetchBranch string
 
@@ -43,9 +56,9 @@ const (
 
 type parentObservation struct {
 	host       string
-	outcome    string // "noerror" | "nxdomain" | "timeout" | "err"
-	errMsg     string
-	nsReturned int
+	outcome    parentOutcome
+	errMsg     string // populated only on timeout/err
+	nsReturned int    // populated only on noerror
 }
 
 type nsVerifyObservation struct {
@@ -61,9 +74,6 @@ var (
 	nsDebugOnce     sync.Once
 	nsDebugOn       bool
 	nsDebugSuffixes []string
-
-	parentStatsMu sync.Mutex
-	parentStats   = map[string]*parentStatRow{}
 )
 
 // nsDebugEnabled reports whether debug logging is on. Cached after first call.
@@ -96,22 +106,32 @@ func nsDebugMatchesTraceSuffix(domain string) bool {
 	return false
 }
 
-func resetParentStats() {
-	parentStatsMu.Lock()
-	defer parentStatsMu.Unlock()
-	parentStats = map[string]*parentStatRow{}
+// nsDebugger is the per-invocation debug state. Goroutine-safe; nil-safe.
+type nsDebugger struct {
+	mut         sync.Mutex
+	parentStats map[string]*parentStatRow
 }
 
-func recordParentStat(host string, outcome parentOutcome) {
+// newNSDebugger returns an initialized debugger when ZONEDB_DEBUG_NS is set,
+// nil otherwise. A nil *nsDebugger is the normal "debug off" value.
+func newNSDebugger() *nsDebugger {
 	if !nsDebugEnabled() {
+		return nil
+	}
+	return &nsDebugger{parentStats: map[string]*parentStatRow{}}
+}
+
+// recordParentStat tallies a single parent-query outcome. No-op on nil.
+func (d *nsDebugger) recordParentStat(host string, outcome parentOutcome) {
+	if d == nil {
 		return
 	}
-	parentStatsMu.Lock()
-	defer parentStatsMu.Unlock()
-	row := parentStats[host]
+	d.mut.Lock()
+	defer d.mut.Unlock()
+	row := d.parentStats[host]
 	if row == nil {
 		row = &parentStatRow{}
-		parentStats[host] = row
+		d.parentStats[host] = row
 	}
 	row.queries++
 	switch outcome {
@@ -126,17 +146,19 @@ func recordParentStat(host string, outcome parentOutcome) {
 	}
 }
 
-func emitParentStats() {
-	if !nsDebugEnabled() {
+// EmitParentStats writes one PARENT_STATS line per distinct parent host seen.
+// No-op on nil.
+func (d *nsDebugger) EmitParentStats() {
+	if d == nil {
 		return
 	}
 	// Snapshot under a single lock, then sort and emit without holding it.
-	parentStatsMu.Lock()
-	snapshot := make(map[string]parentStatRow, len(parentStats))
-	for h, r := range parentStats {
+	d.mut.Lock()
+	snapshot := make(map[string]parentStatRow, len(d.parentStats))
+	for h, r := range d.parentStats {
 		snapshot[h] = *r
 	}
-	parentStatsMu.Unlock()
+	d.mut.Unlock()
 
 	hosts := make([]string, 0, len(snapshot))
 	for h := range snapshot {
@@ -150,76 +172,126 @@ func emitParentStats() {
 	}
 }
 
-// emitFetchObservation is called once per zone after FetchNameServers has
-// finished processing it. Emits NS_CHANGE for changed zones, NS_TRACE for
-// zones matching ZONEDB_DEBUG_NS_SUFFIX regardless of change.
-func emitFetchObservation(
-	z *Zone,
-	parentNS []string,
-	obs []parentObservation,
-	counts map[string]int,
-	successful int,
-	branch fetchBranch,
-) {
-	if !nsDebugEnabled() {
+// emitKind decides whether a zone's observation should produce an NS_CHANGE
+// line, an NS_TRACE line, or nothing. Returns empty string to skip.
+func emitKind(domain string, changed bool) string {
+	if changed {
+		return "NS_CHANGE"
+	}
+	if nsDebugMatchesTraceSuffix(domain) {
+		return "NS_TRACE"
+	}
+	return ""
+}
+
+// fetchZoneObserver collects per-parent observations for a single zone.
+type fetchZoneObserver struct {
+	debugger  *nsDebugger
+	zone      *Zone
+	perParent []parentObservation
+}
+
+// ForFetchZone returns an observer for a single zone. No-op on nil: returns
+// nil, which every *fetchZoneObserver method tolerates.
+func (d *nsDebugger) ForFetchZone(z *Zone, parentCount int) *fetchZoneObserver {
+	if d == nil {
+		return nil
+	}
+	return &fetchZoneObserver{
+		debugger:  d,
+		zone:      z,
+		perParent: make([]parentObservation, 0, parentCount),
+	}
+}
+
+// ObserveParent records a parent-query observation both per-zone (for emit)
+// and in the cross-zone parent-stats tally. No-op on nil.
+func (o *fetchZoneObserver) ObserveParent(observation parentObservation) {
+	if o == nil {
 		return
 	}
-	changed := branch != fetchBranchUnchanged
-	trace := nsDebugMatchesTraceSuffix(z.Domain)
-	if !changed && !trace {
+	o.perParent = append(o.perParent, observation)
+	o.debugger.recordParentStat(observation.host, observation.outcome)
+}
+
+// EmitFetch writes NS_CHANGE for changed zones and NS_TRACE for zones matching
+// ZONEDB_DEBUG_NS_SUFFIX. No-op on nil.
+func (o *fetchZoneObserver) EmitFetch(parentNS []string, counts map[string]int, successful int, branch fetchBranch) {
+	if o == nil {
 		return
 	}
-	kind := "NS_CHANGE"
-	if !changed {
-		kind = "NS_TRACE"
+	kind := emitKind(o.zone.Domain, branch != fetchBranchUnchanged)
+	if kind == "" {
+		return
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s step=fetch branch=%s zone=%s old=%s new=%s parents=%d successful=%d counts=%s\n",
-		kind, branch, z.Domain,
-		formatNSList(z.oldNameServers), formatNSList(z.NameServers),
+		kind, branch, o.zone.Domain,
+		formatNSList(o.zone.oldNameServers), formatNSList(o.zone.NameServers),
 		len(parentNS), successful, formatCounts(counts))
-	for _, o := range obs {
-		switch o.outcome {
-		case "noerror":
-			fmt.Fprintf(&b, "  parent=%s outcome=noerror ns_returned=%d\n", o.host, o.nsReturned)
-		case "nxdomain":
-			fmt.Fprintf(&b, "  parent=%s outcome=nxdomain\n", o.host)
-		case "timeout":
-			fmt.Fprintf(&b, "  parent=%s outcome=timeout err=%q\n", o.host, o.errMsg)
-		case "err":
-			fmt.Fprintf(&b, "  parent=%s outcome=err err=%q\n", o.host, o.errMsg)
+	for _, p := range o.perParent {
+		switch p.outcome {
+		case parentOutcomeNOERROR:
+			fmt.Fprintf(&b, "  parent=%s outcome=%s ns_returned=%d\n", p.host, p.outcome, p.nsReturned)
+		case parentOutcomeNXDOMAIN:
+			fmt.Fprintf(&b, "  parent=%s outcome=%s\n", p.host, p.outcome)
+		case parentOutcomeTimeout, parentOutcomeOtherErr:
+			fmt.Fprintf(&b, "  parent=%s outcome=%s err=%q\n", p.host, p.outcome, p.errMsg)
 		}
 	}
 	color.Fprintf(os.Stderr, "%s", b.String())
 }
 
-// emitVerifyObservation is the Verify-step analog of emitFetchObservation.
-func emitVerifyObservation(
-	z *Zone,
-	prior []string,
-	obs []nsVerifyObservation,
-	branch verifyBranch,
-) {
-	if !nsDebugEnabled() {
+// verifyZoneObserver collects per-NS verification results for a single zone.
+type verifyZoneObserver struct {
+	zone  *Zone
+	prior []string
+	perNS []nsVerifyObservation
+}
+
+// ForVerifyZone returns an observer for a single zone. No-op on nil.
+func (d *nsDebugger) ForVerifyZone(z *Zone, prior []string) *verifyZoneObserver {
+	if d == nil {
+		return nil
+	}
+	return &verifyZoneObserver{
+		zone:  z,
+		prior: prior,
+		perNS: make([]nsVerifyObservation, 0, len(prior)),
+	}
+}
+
+// ObserveNS records a verifyNS outcome. err is nil on success. No-op on nil.
+func (o *verifyZoneObserver) ObserveNS(ns string, err error) {
+	if o == nil {
 		return
 	}
-	changed := branch != verifyBranchUnchanged
-	trace := nsDebugMatchesTraceSuffix(z.Domain)
-	if !changed && !trace {
+	observation := nsVerifyObservation{ns: ns}
+	if err != nil {
+		observation.errMsg = err.Error()
+	}
+	o.perNS = append(o.perNS, observation)
+}
+
+// EmitVerify writes NS_CHANGE for dropped NSs and NS_TRACE for zones matching
+// ZONEDB_DEBUG_NS_SUFFIX. No-op on nil.
+func (o *verifyZoneObserver) EmitVerify(branch verifyBranch) {
+	if o == nil {
 		return
 	}
-	kind := "NS_CHANGE"
-	if !changed {
-		kind = "NS_TRACE"
+	kind := emitKind(o.zone.Domain, branch != verifyBranchUnchanged)
+	if kind == "" {
+		return
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s step=verify branch=%s zone=%s old=%s new=%s\n",
-		kind, branch, z.Domain, formatNSList(prior), formatNSList(z.NameServers))
-	for _, o := range obs {
-		if o.errMsg == "" {
-			fmt.Fprintf(&b, "  ns=%s outcome=ok\n", o.ns)
+		kind, branch, o.zone.Domain,
+		formatNSList(o.prior), formatNSList(o.zone.NameServers))
+	for _, p := range o.perNS {
+		if p.errMsg == "" {
+			fmt.Fprintf(&b, "  ns=%s outcome=ok\n", p.ns)
 		} else {
-			fmt.Fprintf(&b, "  ns=%s outcome=fail err=%q\n", o.ns, o.errMsg)
+			fmt.Fprintf(&b, "  ns=%s outcome=fail err=%q\n", p.ns, p.errMsg)
 		}
 	}
 	color.Fprintf(os.Stderr, "%s", b.String())

--- a/internal/build/dns_test.go
+++ b/internal/build/dns_test.go
@@ -66,7 +66,7 @@ func TestFetchNameServers_AllParentsTimeOut(t *testing.T) {
 		"p5": {timeout: true},
 	})
 
-	if err := FetchNameServers(context.Background(), map[string]*Zone{"example.tld": child}, allZones); err != nil {
+	if err := FetchNameServers(t.Context(), map[string]*Zone{"example.tld": child}, allZones); err != nil {
 		t.Fatalf("FetchNameServers returned error: %v", err)
 	}
 
@@ -96,12 +96,123 @@ func TestFetchNameServers_AllParentsReturnNXDOMAIN(t *testing.T) {
 		"p5": {rcode: dns.RcodeNameError},
 	})
 
-	if err := FetchNameServers(context.Background(), map[string]*Zone{"example.tld": child}, allZones); err != nil {
+	if err := FetchNameServers(t.Context(), map[string]*Zone{"example.tld": child}, allZones); err != nil {
 		t.Fatalf("FetchNameServers returned error: %v", err)
 	}
 
 	if len(child.NameServers) != 0 {
 		t.Errorf("NS list should be cleared on authoritative NXDOMAIN; got %v", child.NameServers)
+	}
+}
+
+// 2 of 10 parents return extras: count==2, max==10, filter keeps them.
+func TestFetchNameServers_PartialConsensus_TwoParents_AddsExtras(t *testing.T) {
+	core := []string{"ns1.core.example", "ns2.core.example", "ns3.core.example", "ns4.core.example"}
+	extras := []string{"extra-a.example", "extra-b.example"}
+
+	parent := &Zone{Domain: "tld", NameServers: []string{"p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9", "p10"}}
+	child := &Zone{Domain: "child.tld", NameServers: slices.Clone(core)}
+	allZones := map[string]*Zone{"tld": parent, "child.tld": child}
+
+	origExchange := exchange
+	t.Cleanup(func() { exchange = origExchange })
+	// 2 parents return core + extras; 8 return core only.
+	withExtras := append(slices.Clone(core), extras...)
+	exchange = scriptedExchange(t, map[string]scriptedResponse{
+		"p1":  {nsRecords: withExtras},
+		"p2":  {nsRecords: withExtras},
+		"p3":  {nsRecords: core},
+		"p4":  {nsRecords: core},
+		"p5":  {nsRecords: core},
+		"p6":  {nsRecords: core},
+		"p7":  {nsRecords: core},
+		"p8":  {nsRecords: core},
+		"p9":  {nsRecords: core},
+		"p10": {nsRecords: core},
+	})
+
+	if err := FetchNameServers(t.Context(), map[string]*Zone{"child.tld": child}, allZones); err != nil {
+		t.Fatalf("FetchNameServers returned error: %v", err)
+	}
+
+	got := sorted(child.NameServers)
+	want := sorted(append(slices.Clone(core), extras...))
+	if !slices.Equal(got, want) {
+		t.Errorf("extras returned by 2/10 parents (count==2) should be kept; got %v, want %v", got, want)
+	}
+}
+
+// 1 of 10 parents returns extras: count==1, max==10, filter drops them.
+func TestFetchNameServers_PartialConsensus_OneParent_DropsExtras(t *testing.T) {
+	core := []string{"ns1.core.example", "ns2.core.example", "ns3.core.example", "ns4.core.example"}
+	extras := []string{"extra-a.example", "extra-b.example"}
+
+	parent := &Zone{Domain: "tld", NameServers: []string{"p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9", "p10"}}
+	child := &Zone{Domain: "child.tld", NameServers: slices.Clone(core)}
+	allZones := map[string]*Zone{"tld": parent, "child.tld": child}
+
+	origExchange := exchange
+	t.Cleanup(func() { exchange = origExchange })
+	// 1 parent returns core + extras; 9 return core only.
+	withExtras := append(slices.Clone(core), extras...)
+	exchange = scriptedExchange(t, map[string]scriptedResponse{
+		"p1":  {nsRecords: withExtras},
+		"p2":  {nsRecords: core},
+		"p3":  {nsRecords: core},
+		"p4":  {nsRecords: core},
+		"p5":  {nsRecords: core},
+		"p6":  {nsRecords: core},
+		"p7":  {nsRecords: core},
+		"p8":  {nsRecords: core},
+		"p9":  {nsRecords: core},
+		"p10": {nsRecords: core},
+	})
+
+	if err := FetchNameServers(t.Context(), map[string]*Zone{"child.tld": child}, allZones); err != nil {
+		t.Fatalf("FetchNameServers returned error: %v", err)
+	}
+
+	got := sorted(child.NameServers)
+	want := sorted(core)
+	if !slices.Equal(got, want) {
+		t.Errorf("extras returned by 1/10 parents (count==1, max==10) should be dropped by consensus filter; got %v, want %v", got, want)
+	}
+}
+
+// Extras in oldNameServers survive count==1 via PR #1124's escape hatch.
+func TestFetchNameServers_PartialConsensus_OneParent_KeepsExtrasIfKnown(t *testing.T) {
+	core := []string{"ns1.core.example", "ns2.core.example", "ns3.core.example", "ns4.core.example"}
+	extras := []string{"extra-a.example", "extra-b.example"}
+	prior := append(slices.Clone(core), extras...)
+
+	parent := &Zone{Domain: "tld", NameServers: []string{"p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9", "p10"}}
+	child := &Zone{Domain: "child.tld", NameServers: slices.Clone(prior)}
+	allZones := map[string]*Zone{"tld": parent, "child.tld": child}
+
+	origExchange := exchange
+	t.Cleanup(func() { exchange = origExchange })
+	withExtras := append(slices.Clone(core), extras...)
+	exchange = scriptedExchange(t, map[string]scriptedResponse{
+		"p1":  {nsRecords: withExtras},
+		"p2":  {nsRecords: core},
+		"p3":  {nsRecords: core},
+		"p4":  {nsRecords: core},
+		"p5":  {nsRecords: core},
+		"p6":  {nsRecords: core},
+		"p7":  {nsRecords: core},
+		"p8":  {nsRecords: core},
+		"p9":  {nsRecords: core},
+		"p10": {nsRecords: core},
+	})
+
+	if err := FetchNameServers(t.Context(), map[string]*Zone{"child.tld": child}, allZones); err != nil {
+		t.Fatalf("FetchNameServers returned error: %v", err)
+	}
+
+	got := sorted(child.NameServers)
+	want := sorted(prior)
+	if !slices.Equal(got, want) {
+		t.Errorf("known extras (in oldNameServers) should survive count==1 filter; got %v, want %v", got, want)
 	}
 }
 
@@ -125,7 +236,7 @@ func TestFetchNameServers_ConsensusFilterKeepsKnownNS(t *testing.T) {
 		"p5": {nsRecords: []string{"ns-a.example", "ns-b.example", "ns-extra.example"}},
 	})
 
-	if err := FetchNameServers(context.Background(), map[string]*Zone{"example.tld": child}, allZones); err != nil {
+	if err := FetchNameServers(t.Context(), map[string]*Zone{"example.tld": child}, allZones); err != nil {
 		t.Fatalf("FetchNameServers returned error: %v", err)
 	}
 

--- a/internal/build/dns_test.go
+++ b/internal/build/dns_test.go
@@ -105,7 +105,8 @@ func TestFetchNameServers_AllParentsReturnNXDOMAIN(t *testing.T) {
 	}
 }
 
-// 2 of 10 parents return extras: count==2, max==10, filter keeps them.
+// Flap first half (paired with *_OneParent_DropsExtras): 2/10 parents return
+// extras, count==2 passes the filter, extras added.
 func TestFetchNameServers_PartialConsensus_TwoParents_AddsExtras(t *testing.T) {
 	core := []string{"ns1.core.example", "ns2.core.example", "ns3.core.example", "ns4.core.example"}
 	extras := []string{"extra-a.example", "extra-b.example"}
@@ -142,7 +143,8 @@ func TestFetchNameServers_PartialConsensus_TwoParents_AddsExtras(t *testing.T) {
 	}
 }
 
-// 1 of 10 parents returns extras: count==1, max==10, filter drops them.
+// Flap second half (paired with *_TwoParents_AddsExtras): same child and
+// prior state, but 1/10 parents return extras, count==1 is dropped.
 func TestFetchNameServers_PartialConsensus_OneParent_DropsExtras(t *testing.T) {
 	core := []string{"ns1.core.example", "ns2.core.example", "ns3.core.example", "ns4.core.example"}
 	extras := []string{"extra-a.example", "extra-b.example"}


### PR DESCRIPTION
This is gated by ZONEDB_DEBUG_NS, which is set in the CI workflow config.