### PR TITLE
NS metadata flapping tests & mitigation

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   update:
     name: Update ZoneDB
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Checkout repo

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -51,6 +51,7 @@ jobs:
           # Temporary NS flap diagnostics; remove once the root cause is found.
           ZONEDB_DEBUG_NS: "1"
           ZONEDB_DEBUG_NS_SUFFIX: "рус"
+          CGO_ENABLED: "0"
         run: make update
 
       - name: Vet Go code

--- a/internal/build/dns.go
+++ b/internal/build/dns.go
@@ -155,9 +155,7 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 			if gctx.Err() != nil {
 				return gctx.Err()
 			}
-			// Punycode IDN hosts: Normalize stores them as Unicode, but Linux
-			// glibc's getaddrinfo requires AI_IDN (which Go does not set) to
-			// resolve Unicode names. Matches verifyNS.
+			// Punycode IDN hosts before resolving. Matches verifyNS.
 			asciiHost, err := idna.ToASCII(host)
 			if err != nil {
 				LogWarningFor(err, host)

--- a/internal/build/dns.go
+++ b/internal/build/dns.go
@@ -158,7 +158,12 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 			// Punycode IDN hosts: Normalize stores them as Unicode, but Linux
 			// glibc's getaddrinfo requires AI_IDN (which Go does not set) to
 			// resolve Unicode names. Matches verifyNS.
-			host, _ = idna.ToASCII(host)
+			asciiHost, err := idna.ToASCII(host)
+			if err != nil {
+				LogWarningFor(err, host)
+				continue
+			}
+			host = asciiHost
 			if _, ok := nx.Load(host); ok {
 				continue
 			}

--- a/internal/build/dns.go
+++ b/internal/build/dns.go
@@ -155,6 +155,10 @@ func FetchNameServers(ctx context.Context, zones, allZones map[string]*Zone) err
 			if gctx.Err() != nil {
 				return gctx.Err()
 			}
+			// Punycode IDN hosts: Normalize stores them as Unicode, but Linux
+			// glibc's getaddrinfo requires AI_IDN (which Go does not set) to
+			// resolve Unicode names. Matches verifyNS.
+			host, _ = idna.ToASCII(host)
 			if _, ok := nx.Load(host); ok {
 				continue
 			}

--- a/internal/build/dns_test.go
+++ b/internal/build/dns_test.go
@@ -248,3 +248,57 @@ func TestFetchNameServers_ConsensusFilterKeepsKnownNS(t *testing.T) {
 		t.Errorf("previously-known NS should not be dropped by consensus filter; got %v, want %v", got, want)
 	}
 }
+
+// Parents with IDN hostnames (stored in Unicode form by Normalize) must be
+// Punycoded before reaching exchange; otherwise glibc resolution fails.
+func TestFetchNameServers_IDNParentHosts_PunycodedForExchange(t *testing.T) {
+	parent := &Zone{Domain: "рус", NameServers: []string{"ns1.nic.рус", "ns2.nic.рус", "ns1.anycastdns.cz"}}
+	prior := []string{"ns1.rlnic.ru", "ns2.rlnic.ru"}
+	child := &Zone{Domain: "001.рус", NameServers: slices.Clone(prior)}
+	allZones := map[string]*Zone{"рус": parent, "001.рус": child}
+
+	origExchange := exchange
+	t.Cleanup(func() { exchange = origExchange })
+	exchange = scriptedExchange(t, map[string]scriptedResponse{
+		"ns1.nic.xn--p1acf": {nsRecords: prior},
+		"ns2.nic.xn--p1acf": {nsRecords: prior},
+		"ns1.anycastdns.cz": {nsRecords: prior},
+	})
+
+	if err := FetchNameServers(t.Context(), map[string]*Zone{"001.рус": child}, allZones); err != nil {
+		t.Fatalf("FetchNameServers returned error: %v", err)
+	}
+
+	got := sorted(child.NameServers)
+	want := sorted(prior)
+	if !slices.Equal(got, want) {
+		t.Errorf("IDN parent hosts must be Punycoded before DNS exchange; got %v, want %v", got, want)
+	}
+}
+
+// Reproduces observed prod flap: 2 IDN parents fail to resolve, 1 non-IDN
+// parent returns NOERROR/0 NS, successful=1 bypasses PR #1124's escape hatch.
+func TestFetchNameServers_IDNParentHost_MixedOutcome_DoesNotFlap(t *testing.T) {
+	parent := &Zone{Domain: "рус", NameServers: []string{"ns1.nic.рус", "ns2.nic.рус", "ns1.anycastdns.cz"}}
+	prior := []string{"ns1.rlnic.ru", "ns2.rlnic.ru"}
+	child := &Zone{Domain: "001.рус", NameServers: slices.Clone(prior)}
+	allZones := map[string]*Zone{"рус": parent, "001.рус": child}
+
+	origExchange := exchange
+	t.Cleanup(func() { exchange = origExchange })
+	exchange = scriptedExchange(t, map[string]scriptedResponse{
+		"ns1.nic.xn--p1acf": {nsRecords: prior},
+		"ns2.nic.xn--p1acf": {nsRecords: prior},
+		"ns1.anycastdns.cz": {nsRecords: nil},
+	})
+
+	if err := FetchNameServers(t.Context(), map[string]*Zone{"001.рус": child}, allZones); err != nil {
+		t.Fatalf("FetchNameServers returned error: %v", err)
+	}
+
+	got := sorted(child.NameServers)
+	want := sorted(prior)
+	if !slices.Equal(got, want) {
+		t.Errorf("zone must not flap when IDN parents are reachable by Punycode; got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
This is a followup to the work in #1124 and #1126.