### PR TITLE
Stop caching transient resolver errors in CanDial

### DIFF
--- a/internal/build/dns.go
+++ b/internal/build/dns.go
@@ -325,7 +325,9 @@ func verifyNS(ctx context.Context, host string) error {
 	if err != nil {
 		return fmt.Errorf("normalizing host %q: %w", host, err)
 	}
-	return CanDial(ctx, "udp", host+":53")
+	qctx, cancel := context.WithTimeout(ctx, VerifyDialTimeout)
+	defer cancel()
+	return CanDial(qctx, "udp", host+":53")
 }
 
 // CountNameServers counts unique name servers for zones.

--- a/internal/build/net.go
+++ b/internal/build/net.go
@@ -22,6 +22,10 @@ var (
 	// DialTimeout bounds the TCP/UDP dial performed by CanDial and queryWhois.
 	// HTTP fetches use httpClient.Timeout (see below), not this value.
 	DialTimeout = 10 * time.Second
+
+	// VerifyDialTimeout bounds verifyNS's local UDP probe.
+	// Not for high-latency paths; queryWhois keeps DialTimeout.
+	VerifyDialTimeout = 2 * time.Second
 )
 
 // httpClient is the shared HTTP client for all build-package fetches.
@@ -86,13 +90,15 @@ func FetchWithETag(ctx context.Context, u string, cache *ETagCache) (*http.Respo
 	return res, nil
 }
 
-// dialer is reused by CanDial and queryWhois to avoid allocating a net.Dialer
-// per call. It has no per-call state that varies with ctx.
+// dialer is reused by queryWhois and (via dialContext) by CanDial.
 var dialer = &net.Dialer{Timeout: DialTimeout}
 
+// dialContext is the dial entry point for CanDial; package-level so tests
+// can substitute it (mirrors var exchange = defaultExchange in dns.go).
+var dialContext = dialer.DialContext
+
 // CanDial reports whether network/addr accepts a connection, discarding it.
-// Results are cached process-wide; ctx-induced errors are not cached so a
-// cancelled dial doesn't poison future callers.
+// Cached process-wide; only durable failures are cached (see cacheable).
 // FIXME: scope the cache per-run instead of package-global.
 func CanDial(ctx context.Context, network, addr string) error {
 	k := network + " " + addr
@@ -102,11 +108,9 @@ func CanDial(ctx context.Context, network, addr string) error {
 	if ok {
 		return err
 	}
-	c, err := dialer.DialContext(ctx, network, addr)
-	// Do not cache ctx-induced errors: a future caller with a fresh ctx
-	// should get a real dial attempt.
+	c, err := dialContext(ctx, network, addr)
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if !cacheable(err) {
 			return err
 		}
 		mtx.Lock()
@@ -119,6 +123,23 @@ func CanDial(ctx context.Context, network, addr string) error {
 	dialCache[k] = nil
 	mtx.Unlock()
 	return nil
+}
+
+// cacheable reports whether err is a durable failure worth caching.
+// Excludes ctx errors and transient network/DNS errors so flakes don't poison.
+func cacheable(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var nerr net.Error
+	if errors.As(err, &nerr) && nerr.Timeout() {
+		return false
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) && dnsErr.IsTemporary {
+		return false
+	}
+	return true
 }
 
 var (

--- a/internal/build/net_test.go
+++ b/internal/build/net_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"testing"
+	"time"
 )
 
 // TestCanDialCacheSkipsCtxErrors: a cancelled dial in one build phase must
@@ -46,5 +47,136 @@ func TestCanDialCacheSkipsCtxErrors(t *testing.T) {
 	// A fresh ctx should successfully dial, proving the cache wasn't poisoned.
 	if err := CanDial(t.Context(), "tcp", addr); err != nil {
 		t.Fatalf("fresh ctx failed to dial: %v", err)
+	}
+}
+
+// TestCanDialDoesNotCacheTransientErrors: a single stub-resolver flake
+// must not poison the cache for later callers of the same host.
+func TestCanDialDoesNotCacheTransientErrors(t *testing.T) {
+	// dnsTimeout reproduces the 2026-05-13 a-dns.pl failure; dnsTemporary
+	// covers non-timeout transient resolver failures (e.g. SERVFAIL).
+	dnsTimeout := &net.OpError{
+		Op:  "dial",
+		Net: "udp",
+		Err: &net.DNSError{
+			Err:       "i/o timeout",
+			Name:      "transient-flake.example.invalid",
+			Server:    "127.0.0.53:53",
+			IsTimeout: true,
+		},
+	}
+	dnsTemporary := &net.DNSError{
+		Err:         "server misbehaving",
+		Name:        "temp-flake.example.invalid",
+		Server:      "127.0.0.53:53",
+		IsTemporary: true,
+	}
+
+	cases := []struct {
+		name string
+		addr string
+		err  error
+	}{
+		{"dns_timeout_wrapped_in_op_error", "transient-flake.example.invalid:53", dnsTimeout},
+		{"dns_temporary", "temp-flake.example.invalid:53", dnsTemporary},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Isolate from prior runs and other tests that may share dialCache.
+			key := "udp " + tc.addr
+			mtx.Lock()
+			delete(dialCache, key)
+			mtx.Unlock()
+			t.Cleanup(func() {
+				mtx.Lock()
+				delete(dialCache, key)
+				mtx.Unlock()
+			})
+
+			// Substitute the dialer to force the chosen transient error and
+			// count invocations. Restored via t.Cleanup.
+			var calls int
+			orig := dialContext
+			t.Cleanup(func() { dialContext = orig })
+			dialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
+				calls++
+				return nil, tc.err
+			}
+
+			// First call: must return the transient error to the caller.
+			if err := CanDial(t.Context(), "udp", tc.addr); err == nil {
+				t.Fatal("expected transient error from first call, got nil")
+			}
+
+			// The contract under test: the transient error must not be cached.
+			mtx.RLock()
+			_, cached := dialCache[key]
+			mtx.RUnlock()
+			if cached {
+				t.Fatal("transient error was cached; cache would poison future callers (the May 13 .pl flap)")
+			}
+
+			// Second call: must re-dial (calls == 2), not short-circuit on cache.
+			if err := CanDial(t.Context(), "udp", tc.addr); err == nil {
+				t.Fatal("expected transient error from second call, got nil")
+			}
+			if calls != 2 {
+				t.Fatalf("dialer was called %d times; want 2 (cache must not short-circuit transient failures)", calls)
+			}
+		})
+	}
+}
+
+// TestCanDialCachesDurableErrors: connection-refused stays cached, so
+// known-bad endpoints aren't re-dialled within a build run.
+func TestCanDialCachesDurableErrors(t *testing.T) {
+	// Bind then immediately close to obtain an address that the OS
+	// will refuse connections on — a deterministic durable error.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Isolate from prior runs and other tests that may share dialCache.
+	key := "tcp " + addr
+	mtx.Lock()
+	delete(dialCache, key)
+	mtx.Unlock()
+	t.Cleanup(func() {
+		mtx.Lock()
+		delete(dialCache, key)
+		mtx.Unlock()
+	})
+
+	// Act: a single dial attempt that should hit the closed port.
+	if err := CanDial(t.Context(), "tcp", addr); err == nil {
+		t.Fatal("expected connection-refused error, got nil")
+	}
+
+	// The contract under test: durable errors must be cached.
+	mtx.RLock()
+	_, cached := dialCache[key]
+	mtx.RUnlock()
+	if !cached {
+		t.Fatal("durable error was not cached; we should not re-dial known-bad endpoints")
+	}
+}
+
+// TestVerifyDialTimeout pins the policy that verify probes use a
+// tighter dial budget than DialTimeout.
+func TestVerifyDialTimeout(t *testing.T) {
+	if VerifyDialTimeout >= DialTimeout {
+		t.Fatalf("VerifyDialTimeout (%v) must be tighter than DialTimeout (%v)", VerifyDialTimeout, DialTimeout)
+	}
+	if VerifyDialTimeout <= 0 {
+		t.Fatalf("VerifyDialTimeout must be positive, got %v", VerifyDialTimeout)
+	}
+	if VerifyDialTimeout > 5*time.Second {
+		t.Fatalf("VerifyDialTimeout (%v) is generous for a UDP local-socket probe; expected ≤5s", VerifyDialTimeout)
 	}
 }


### PR DESCRIPTION
## Issue

Day-over-day flap on `.pl` zones: 154 verify-side drops of `a-dns.pl` on 2026-05-13, 153 fetch-side re-adds on 2026-05-14. Same zones, opposite direction, no upstream NS change.

## Root cause

`verifyNS` calls `CanDial(ctx, "udp", host+":53")`. A UDP `Dial` is local-only on Go's `net.Dialer`: it resolves the hostname through the runner's stub and opens a kernel socket. **No packet reaches the target NS.** So `verifyNS` is a stub-resolver health probe, not a reachability probe.

`CanDial`'s process-wide `dialCache` previously cached every non-ctx error. When the runner's stub (`127.0.0.53:53`) flaked once on `a-dns.pl`, the cached `*net.OpError` short-circuited every later `.pl` caller in the same run, dropping `a-dns.pl` from 153 zones. The next night the stub recovered, the cache started fresh, and the same 153 zones added it back.

## Fix

- New `cacheable()` helper excludes `context.Canceled`, `context.DeadlineExceeded`, and transient `net.Error` (`Timeout()` or `Temporary()`) from the cache, so a single flake no longer fans out.
- `verifyNS` wraps ctx with a new `VerifyDialTimeout = 2s` budget; the probe is local, so >2s implies the runner itself is unhealthy and shouldn't be cached as durable.
- `queryWhois` is unaffected: it keeps the 10s `DialTimeout` and the shared `*net.Dialer`. Only the verify path picks up the tighter bound.
- Test seam: `var dialContext = dialer.DialContext` mirrors the existing `var exchange = defaultExchange` pattern in `dns.go`.

Durable failures (connection refused, `NXDOMAIN`-class) are still cached. Whois behavior is unchanged.